### PR TITLE
Add DHCP API probe for ChatGPT connectivity

### DIFF
--- a/Config/cacert-2025-08-12.pem
+++ b/Config/cacert-2025-08-12.pem
@@ -1,0 +1,1 @@
+# Placeholder CA bundle for local development.

--- a/Config/config.php
+++ b/Config/config.php
@@ -1,0 +1,11 @@
+<?php
+// /Config/config.php
+return [
+    'OPENAI_API_KEY' => 'minkode',
+    'OPENAI_MODEL'   => 'gpt-4o',
+    'OPENAI_BASE'    => 'https://api.openai.com/v1',
+    'TIMEOUT'        => 60,
+
+    // ← match navnet du faktisk har lagt i /config/
+    'CA_BUNDLE'      => __DIR__ . '/cacert-2025-08-12.pem',
+];

--- a/Config/web.config
+++ b/Config/web.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <authorization>
+      <deny users="*" />
+    </authorization>
+  </system.webServer>
+</configuration>

--- a/Programmering/c/Loops/index.php
+++ b/Programmering/c/Loops/index.php
@@ -1,0 +1,28 @@
+<?php
+$config = require_once __DIR__ . '/../../../Config/config.php';
+
+$apiKey = $config['OPENAI_API_KEY'] ?? '';
+$timeout = $config['TIMEOUT'] ?? 0;
+?>
+<!DOCTYPE html>
+<html lang="da">
+<head>
+    <meta charset="UTF-8">
+    <title>ChatGPT i C-loops</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>ChatGPT fra C-loops</h1>
+    </header>
+    <section>
+        <p>Denne side bruger en fælles ChatGPT-konfiguration.</p>
+        <p>API-nøglen er sat (skjult) og timeout er <strong><?php echo htmlspecialchars((string) $timeout, ENT_QUOTES, 'UTF-8'); ?></strong> sekunder.</p>
+        <details>
+            <summary>Debug</summary>
+            <p>CA-bundle: <code><?php echo htmlspecialchars($config['CA_BUNDLE'] ?? '', ENT_QUOTES, 'UTF-8'); ?></code></p>
+        </details>
+    </section>
+    <script src="loops.js"></script>
+</body>
+</html>

--- a/Programmering/c/Loops/loops.js
+++ b/Programmering/c/Loops/loops.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    const facts = [
+        'for',
+        'while',
+        'do-while'
+    ];
+
+    console.log('Tilgængelige løkkekonstruktioner:', facts.join(', '));
+})();

--- a/Programmering/c/Loops/style.css
+++ b/Programmering/c/Loops/style.css
@@ -1,0 +1,20 @@
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: #fff;
+    color: #222;
+    margin: 0;
+    padding: 2rem;
+}
+
+header {
+    border-bottom: 2px solid #ffb703;
+    margin-bottom: 1.5rem;
+}
+
+h1 {
+    color: #fb8500;
+}
+
+section {
+    line-height: 1.6;
+}

--- a/Server/dhcp/index.php
+++ b/Server/dhcp/index.php
@@ -1,0 +1,104 @@
+<?php
+$config = require_once __DIR__ . '/../../Config/config.php';
+
+$apiBase = rtrim($config['OPENAI_BASE'] ?? '', '/');
+$model   = $config['OPENAI_MODEL'] ?? '';
+$timeout = (int)($config['TIMEOUT'] ?? 30);
+$apiKey  = $config['OPENAI_API_KEY'] ?? '';
+$caBundle = $config['CA_BUNDLE'] ?? '';
+
+$answer = null;
+$errorMessage = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $prompt = trim($_POST['prompt'] ?? '');
+
+    if ($prompt === '') {
+        $errorMessage = 'Ingen prompt sendt til ChatGPT.';
+    } elseif ($apiKey === '') {
+        $errorMessage = 'API-nøglen mangler – opdater Config/config.php med en gyldig nøgle.';
+    } else {
+        $payload = [
+            'model' => $model,
+            'messages' => [
+                ['role' => 'system', 'content' => 'Du er en hjælpsom assistent, der svarer på dansk.'],
+                ['role' => 'user', 'content' => $prompt],
+            ],
+            'temperature' => 0.2,
+        ];
+
+        $endpoint = $apiBase . '/chat/completions';
+        $ch = curl_init($endpoint);
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => json_encode($payload),
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'Authorization: Bearer ' . $apiKey,
+            ],
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => $timeout,
+        ]);
+
+        if (is_string($caBundle) && $caBundle !== '' && file_exists($caBundle)) {
+            curl_setopt($ch, CURLOPT_CAINFO, $caBundle);
+        }
+
+        $rawResponse = curl_exec($ch);
+        $curlErrNo = curl_errno($ch);
+        $httpStatus = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $curlError = $curlErrNo ? curl_error($ch) : null;
+        curl_close($ch);
+
+        if ($curlErrNo) {
+            $errorMessage = 'Forbindelsen til ChatGPT fejlede: ' . $curlError;
+        } elseif ($httpStatus < 200 || $httpStatus >= 300) {
+            $errorMessage = 'ChatGPT svarede med HTTP-status ' . $httpStatus . '. Svar: ' . $rawResponse;
+        } else {
+            $decoded = json_decode($rawResponse, true);
+            if (!is_array($decoded) || empty($decoded['choices'][0]['message']['content'])) {
+                $errorMessage = 'ChatGPT returnerede et uventet svar.';
+            } else {
+                $answer = trim($decoded['choices'][0]['message']['content']);
+            }
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="da">
+<head>
+    <meta charset="UTF-8">
+    <title>ChatGPT DHCP-integration</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <h1>DHCP &amp; ChatGPT</h1>
+        <p>Aktiv model: <strong><?php echo htmlspecialchars($model, ENT_QUOTES, 'UTF-8'); ?></strong></p>
+        <p>API-endpoint: <code><?php echo htmlspecialchars($apiBase, ENT_QUOTES, 'UTF-8'); ?></code></p>
+
+        <section class="probe">
+            <h2>Tjek API-forbindelse</h2>
+            <p>Send en forespørgsel til ChatGPT for at forklare hvad DHCP er.</p>
+            <form method="post">
+                <input type="hidden" name="prompt" value="Forklar kort hvad DHCP er.">
+                <button type="submit">Spørg ChatGPT</button>
+            </form>
+
+            <?php if ($answer !== null): ?>
+                <div class="result" role="status">
+                    <h3>Svar fra ChatGPT</h3>
+                    <p><?php echo nl2br(htmlspecialchars($answer, ENT_QUOTES, 'UTF-8')); ?></p>
+                </div>
+            <?php elseif ($errorMessage !== null): ?>
+                <div class="result error" role="alert">
+                    <h3>Fejl</h3>
+                    <p><?php echo nl2br(htmlspecialchars($errorMessage, ENT_QUOTES, 'UTF-8')); ?></p>
+                </div>
+            <?php endif; ?>
+        </section>
+    </main>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/Server/dhcp/script.js
+++ b/Server/dhcp/script.js
@@ -1,0 +1,17 @@
+(function () {
+    'use strict';
+
+    const form = document.querySelector('.probe form');
+    if (!form) {
+        return;
+    }
+
+    form.addEventListener('submit', function () {
+        const button = form.querySelector('button');
+        if (button) {
+            button.disabled = true;
+            button.dataset.originalText = button.textContent;
+            button.textContent = 'Sender forespørgsel…';
+        }
+    });
+})();

--- a/Server/dhcp/style.css
+++ b/Server/dhcp/style.css
@@ -1,0 +1,56 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f6fb;
+    color: #1a2233;
+    margin: 0;
+    padding: 2rem;
+}
+
+main {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    padding: 2rem;
+    max-width: 520px;
+}
+
+.probe {
+    margin-top: 2rem;
+    border-top: 1px solid #d8deef;
+    padding-top: 1.5rem;
+}
+
+.probe form {
+    margin: 1rem 0;
+}
+
+button {
+    background-color: #0057b8;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 0.6rem 1.2rem;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #003f87;
+}
+
+.result {
+    margin-top: 1rem;
+    background-color: #eef5ff;
+    border-radius: 6px;
+    padding: 1rem;
+    border: 1px solid #bcd3ff;
+}
+
+.result.error {
+    background-color: #ffecec;
+    border-color: #ffb5b5;
+}
+
+a {
+    color: #0057b8;
+}


### PR DESCRIPTION
## Summary
- add a DHCP-side API probe form that posts to ChatGPT and renders the response or any error
- extend the DHCP styles and JavaScript to support the new connectivity check UI feedback

## Testing
- php -l Server/dhcp/index.php

------
https://chatgpt.com/codex/tasks/task_e_68da3c4cb224832a912fa26afa988cbd