### PR TITLE
Create PHP-friendly subnetting simulator page

### DIFF
--- a/api/check-subnet-task.php
+++ b/api/check-subnet-task.php
@@ -20,50 +20,73 @@ function decodePayload(string $raw): array
     return $data;
 }
 
-function resolveConfigDir(): string
+function findConfigFile(): array
 {
     $candidates = [];
+    $checked = [];
+
+    $envFile = getenv('CONFIG_FILE');
+    if (is_string($envFile) && $envFile !== '') {
+        $candidates[] = $envFile;
+        $candidates[] = __DIR__ . '/' . ltrim($envFile, '/\\');
+        $candidates[] = dirname(__DIR__) . '/' . ltrim($envFile, '/\\');
+    }
 
     $envDir = getenv('CONFIG_DIR');
     if (is_string($envDir) && $envDir !== '') {
-        $candidates[] = rtrim($envDir, "\\/");
+        $dir = rtrim($envDir, "\\/");
+        $candidates[] = $dir . '/config.php';
+        $candidates[] = $dir . '/config.phg';
     }
 
-    $candidates[] = __DIR__ . '/config';
-    $candidates[] = dirname(__DIR__) . '/config';
-    $candidates[] = dirname(__DIR__, 2) . '/Config';
-    $candidates[] = dirname(__DIR__, 2) . '/config';
+    $bases = [__DIR__, dirname(__DIR__), dirname(__DIR__, 2), dirname(__DIR__, 3)];
+    foreach ($bases as $base) {
+        if (!is_string($base) || $base === '') {
+            continue;
+        }
+        $base = rtrim($base, "\\/");
+        if ($base === '') {
+            continue;
+        }
+        $candidates[] = $base . '/config.php';
+        $candidates[] = $base . '/Config.php';
+        $candidates[] = $base . '/config/config.php';
+        $candidates[] = $base . '/config/config.phg';
+        $candidates[] = $base . '/Config/config.php';
+        $candidates[] = $base . '/Config/config.phg';
+    }
 
-    foreach ($candidates as $dir) {
-        if ($dir && is_dir($dir)) {
-            return $dir;
+    $seen = [];
+    foreach ($candidates as $candidate) {
+        if (!$candidate) {
+            continue;
+        }
+        $normalized = preg_replace('#[\\/]+#', '/', $candidate);
+        if (isset($seen[$normalized])) {
+            continue;
+        }
+        $seen[$normalized] = true;
+        $checked[] = $normalized;
+        if (is_readable($candidate) && !is_dir($candidate)) {
+            return [$candidate, dirname($candidate), $checked];
         }
     }
 
-    return $candidates[0];
+    return [null, null, $checked];
 }
 
-function loadCredentials(string $configDir): array
+function loadCredentials(): array
 {
     $apiKey = null;
     $caBundle = null;
     $baseUrl = 'https://api.openai.com/v1';
     $model = 'gpt-4o-mini';
     $timeout = 30;
-    $configPathUsed = null;
 
-    $configFiles = ['config.php', 'config.phg'];
+    [$configPath, $configDir, $checkedPaths] = findConfigFile();
 
-    foreach ($configFiles as $candidate) {
-        $candidatePath = $configDir . '/' . $candidate;
-        if (is_readable($candidatePath)) {
-            $configPathUsed = $candidatePath;
-            break;
-        }
-    }
-
-    if ($configPathUsed) {
-        $loaded = require $configPathUsed;
+    if ($configPath) {
+        $loaded = require $configPath;
         if (is_string($loaded)) {
             $apiKey = trim($loaded);
         } elseif (is_array($loaded)) {
@@ -73,7 +96,7 @@ function loadCredentials(string $configDir): array
             if (isset($loaded['CA_BUNDLE'])) {
                 $candidate = trim((string) $loaded['CA_BUNDLE']);
                 if ($candidate !== '') {
-                    if (!is_readable($candidate)) {
+                    if (!is_readable($candidate) && $configDir) {
                         $relative = $configDir . '/' . ltrim($candidate, '/\\');
                         if (is_readable($relative)) {
                             $candidate = $relative;
@@ -104,7 +127,7 @@ function loadCredentials(string $configDir): array
         }
     }
 
-    if (!$caBundle) {
+    if (!$caBundle && $configDir) {
         $defaultCa = $configDir . '/cacert.pem';
         if (is_readable($defaultCa)) {
             $caBundle = $defaultCa;
@@ -133,7 +156,7 @@ function loadCredentials(string $configDir): array
     $envCa = getenv('OPENAI_CA_BUNDLE');
     if (!$caBundle && is_string($envCa) && trim($envCa) !== '') {
         $candidate = trim($envCa);
-        if (!is_readable($candidate)) {
+        if (!is_readable($candidate) && $configDir) {
             $relative = $configDir . '/' . ltrim($candidate, '/\\');
             if (is_readable($relative)) {
                 $candidate = $relative;
@@ -150,7 +173,8 @@ function loadCredentials(string $configDir): array
         'baseUrl' => $baseUrl,
         'model' => $model,
         'timeout' => $timeout,
-        'configPath' => $configPathUsed,
+        'configPath' => $configPath,
+        'checkedPaths' => $checkedPaths,
     ];
 }
 
@@ -207,10 +231,22 @@ $expected = (string) ($task['expectedAnswer'] ?? '');
 $explanation = (string) ($task['explanation'] ?? '');
 $prompt = (string) ($task['prompt'] ?? '');
 
-$credentials = loadCredentials(resolveConfigDir());
+$credentials = loadCredentials();
 if ($credentials['apiKey'] === '') {
+    $searched = $credentials['checkedPaths'] ?? [];
+    $hint = '';
+    if (!empty($credentials['configPath'])) {
+        $hint = ' Forsøgte at bruge: ' . $credentials['configPath'] . '.';
+    } elseif (!empty($searched)) {
+        $preview = array_slice($searched, 0, 5);
+        if (count($searched) > 5) {
+            $preview[] = '…';
+        }
+        $hint = ' Søgte i: ' . implode(', ', $preview) . '.';
+    }
+
     respond([
-        'error' => 'Serveren mangler OpenAI API-nøglen. Tjek config/config.php (feltet OPENAI_API_KEY) eller miljøvariablen OPENAI_API_KEY.'
+        'error' => 'Serveren mangler OpenAI API-nøglen. Tjek config/config.php (feltet OPENAI_API_KEY) eller miljøvariablen OPENAI_API_KEY.' . $hint
     ], 500);
 }
 

--- a/api/check-subnet-task.php
+++ b/api/check-subnet-task.php
@@ -47,20 +47,23 @@ function loadCredentials(string $configDir): array
 {
     $apiKey = null;
     $caBundle = null;
+    $baseUrl = 'https://api.openai.com/v1';
+    $model = 'gpt-4o-mini';
+    $timeout = 30;
+    $configPathUsed = null;
 
     $configFiles = ['config.php', 'config.phg'];
-    $configPath = null;
 
     foreach ($configFiles as $candidate) {
         $candidatePath = $configDir . '/' . $candidate;
         if (is_readable($candidatePath)) {
-            $configPath = $candidatePath;
+            $configPathUsed = $candidatePath;
             break;
         }
     }
 
-    if ($configPath) {
-        $loaded = require $configPath;
+    if ($configPathUsed) {
+        $loaded = require $configPathUsed;
         if (is_string($loaded)) {
             $apiKey = trim($loaded);
         } elseif (is_array($loaded)) {
@@ -81,6 +84,23 @@ function loadCredentials(string $configDir): array
                     }
                 }
             }
+            if (isset($loaded['OPENAI_BASE'])) {
+                $trimmedBase = trim((string) $loaded['OPENAI_BASE']);
+                if ($trimmedBase !== '') {
+                    $baseUrl = $trimmedBase;
+                }
+            }
+            if (isset($loaded['OPENAI_MODEL'])) {
+                $trimmedModel = trim((string) $loaded['OPENAI_MODEL']);
+                if ($trimmedModel !== '') {
+                    $model = $trimmedModel;
+                }
+            }
+            if (isset($loaded['TIMEOUT'])) {
+                $timeout = max(0, (int) $loaded['TIMEOUT']);
+            } elseif (isset($loaded['OPENAI_TIMEOUT'])) {
+                $timeout = max(0, (int) $loaded['OPENAI_TIMEOUT']);
+            }
         }
     }
 
@@ -95,7 +115,43 @@ function loadCredentials(string $configDir): array
         $apiKey = getenv('OPENAI_API_KEY') ?: '';
     }
 
-    return [$apiKey, $caBundle];
+    $envBase = getenv('OPENAI_BASE');
+    if (is_string($envBase) && trim($envBase) !== '') {
+        $baseUrl = trim($envBase);
+    }
+
+    $envModel = getenv('OPENAI_MODEL');
+    if (is_string($envModel) && trim($envModel) !== '') {
+        $model = trim($envModel);
+    }
+
+    $envTimeout = getenv('OPENAI_TIMEOUT');
+    if (is_string($envTimeout) && trim($envTimeout) !== '') {
+        $timeout = max(0, (int) $envTimeout);
+    }
+
+    $envCa = getenv('OPENAI_CA_BUNDLE');
+    if (!$caBundle && is_string($envCa) && trim($envCa) !== '') {
+        $candidate = trim($envCa);
+        if (!is_readable($candidate)) {
+            $relative = $configDir . '/' . ltrim($candidate, '/\\');
+            if (is_readable($relative)) {
+                $candidate = $relative;
+            }
+        }
+        if (is_readable($candidate)) {
+            $caBundle = $candidate;
+        }
+    }
+
+    return [
+        'apiKey' => $apiKey ?: '',
+        'caBundle' => $caBundle,
+        'baseUrl' => $baseUrl,
+        'model' => $model,
+        'timeout' => $timeout,
+        'configPath' => $configPathUsed,
+    ];
 }
 
 function loadTasks(string $path): array
@@ -151,13 +207,17 @@ $expected = (string) ($task['expectedAnswer'] ?? '');
 $explanation = (string) ($task['explanation'] ?? '');
 $prompt = (string) ($task['prompt'] ?? '');
 
-[$apiKey, $caBundle] = loadCredentials(resolveConfigDir());
-if ($apiKey === '') {
-    respond(['error' => 'Serveren mangler OpenAI API-nøglen.'], 500);
+$credentials = loadCredentials(resolveConfigDir());
+if ($credentials['apiKey'] === '') {
+    respond([
+        'error' => 'Serveren mangler OpenAI API-nøglen. Tjek config/config.php (feltet OPENAI_API_KEY) eller miljøvariablen OPENAI_API_KEY.'
+    ], 500);
 }
 
+$endpoint = rtrim($credentials['baseUrl'], '/') . '/chat/completions';
+
 $requestBody = [
-    'model' => 'gpt-4o-mini',
+    'model' => $credentials['model'] !== '' ? $credentials['model'] : 'gpt-4o-mini',
     'temperature' => 0.2,
     'max_tokens' => 280,
     'messages' => [
@@ -178,19 +238,23 @@ $requestBody = [
     ]
 ];
 
-$ch = curl_init('https://api.openai.com/v1/chat/completions');
+$ch = curl_init($endpoint);
 $curlOptions = [
     CURLOPT_POST => true,
     CURLOPT_RETURNTRANSFER => true,
     CURLOPT_HTTPHEADER => [
         'Content-Type: application/json',
-        'Authorization: Bearer ' . $apiKey,
+        'Authorization: Bearer ' . $credentials['apiKey'],
     ],
     CURLOPT_POSTFIELDS => json_encode($requestBody, JSON_UNESCAPED_UNICODE),
 ];
 
-if ($caBundle) {
-    $curlOptions[CURLOPT_CAINFO] = $caBundle;
+if ($credentials['caBundle']) {
+    $curlOptions[CURLOPT_CAINFO] = $credentials['caBundle'];
+}
+
+if ($credentials['timeout'] > 0) {
+    $curlOptions[CURLOPT_TIMEOUT] = $credentials['timeout'];
 }
 
 curl_setopt_array($ch, $curlOptions);

--- a/api/check-subnet-task.php
+++ b/api/check-subnet-task.php
@@ -1,0 +1,238 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+
+function respond(array $payload, int $status = 200): void
+{
+    http_response_code($status);
+    echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function decodePayload(string $raw): array
+{
+    $data = json_decode($raw, true);
+    if (!is_array($data)) {
+        respond(['error' => 'Ugyldigt JSON-format.'], 400);
+    }
+
+    return $data;
+}
+
+function resolveConfigDir(): string
+{
+    $candidates = [];
+
+    $envDir = getenv('CONFIG_DIR');
+    if (is_string($envDir) && $envDir !== '') {
+        $candidates[] = rtrim($envDir, "\\/");
+    }
+
+    $candidates[] = __DIR__ . '/config';
+    $candidates[] = dirname(__DIR__) . '/config';
+    $candidates[] = dirname(__DIR__, 2) . '/Config';
+    $candidates[] = dirname(__DIR__, 2) . '/config';
+
+    foreach ($candidates as $dir) {
+        if ($dir && is_dir($dir)) {
+            return $dir;
+        }
+    }
+
+    return $candidates[0];
+}
+
+function loadCredentials(string $configDir): array
+{
+    $apiKey = null;
+    $caBundle = null;
+
+    $configFiles = ['config.php', 'config.phg'];
+    $configPath = null;
+
+    foreach ($configFiles as $candidate) {
+        $candidatePath = $configDir . '/' . $candidate;
+        if (is_readable($candidatePath)) {
+            $configPath = $candidatePath;
+            break;
+        }
+    }
+
+    if ($configPath) {
+        $loaded = require $configPath;
+        if (is_string($loaded)) {
+            $apiKey = trim($loaded);
+        } elseif (is_array($loaded)) {
+            if (isset($loaded['OPENAI_API_KEY'])) {
+                $apiKey = trim((string) $loaded['OPENAI_API_KEY']);
+            }
+            if (isset($loaded['CA_BUNDLE'])) {
+                $candidate = trim((string) $loaded['CA_BUNDLE']);
+                if ($candidate !== '') {
+                    if (!is_readable($candidate)) {
+                        $relative = $configDir . '/' . ltrim($candidate, '/\\');
+                        if (is_readable($relative)) {
+                            $candidate = $relative;
+                        }
+                    }
+                    if (is_readable($candidate)) {
+                        $caBundle = $candidate;
+                    }
+                }
+            }
+        }
+    }
+
+    if (!$caBundle) {
+        $defaultCa = $configDir . '/cacert.pem';
+        if (is_readable($defaultCa)) {
+            $caBundle = $defaultCa;
+        }
+    }
+
+    if (!$apiKey) {
+        $apiKey = getenv('OPENAI_API_KEY') ?: '';
+    }
+
+    return [$apiKey, $caBundle];
+}
+
+function loadTasks(string $path): array
+{
+    if (!is_readable($path)) {
+        respond(['error' => 'Kan ikke finde opgavefilen.'], 500);
+    }
+
+    $raw = file_get_contents($path);
+    if ($raw === false) {
+        respond(['error' => 'Kan ikke læse opgavefilen.'], 500);
+    }
+
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded)) {
+        respond(['error' => 'Opgavefilen har et ugyldigt format.'], 500);
+    }
+
+    $map = [];
+    foreach ($decoded as $task) {
+        if (isset($task['id'])) {
+            $map[(int) $task['id']] = $task;
+        }
+    }
+
+    return $map;
+}
+
+$rawInput = file_get_contents('php://input');
+if ($rawInput === false) {
+    respond(['error' => 'Kunne ikke læse forespørgslen.'], 400);
+}
+
+$payload = decodePayload($rawInput);
+$taskId = isset($payload['taskId']) ? (int) $payload['taskId'] : 0;
+$answer = isset($payload['answer']) ? trim((string) $payload['answer']) : '';
+
+if ($taskId <= 0) {
+    respond(['error' => 'Mangler gyldigt taskId.'], 400);
+}
+
+if ($answer === '') {
+    respond(['error' => 'Skriv et svar, før du sender.'], 400);
+}
+
+$tasks = loadTasks(dirname(__DIR__) . '/data/subnet_tasks.json');
+if (!isset($tasks[$taskId])) {
+    respond(['error' => 'Opgaven findes ikke.'], 404);
+}
+
+$task = $tasks[$taskId];
+$expected = (string) ($task['expectedAnswer'] ?? '');
+$explanation = (string) ($task['explanation'] ?? '');
+$prompt = (string) ($task['prompt'] ?? '');
+
+[$apiKey, $caBundle] = loadCredentials(resolveConfigDir());
+if ($apiKey === '') {
+    respond(['error' => 'Serveren mangler OpenAI API-nøglen.'], 500);
+}
+
+$requestBody = [
+    'model' => 'gpt-4o-mini',
+    'temperature' => 0.2,
+    'max_tokens' => 280,
+    'messages' => [
+        [
+            'role' => 'system',
+            'content' => 'Du er en hjælpsom underviser i subnetting. Du skal svare med JSON på formen {"status":"correct|incorrect","feedback":"kort forklaring på dansk"}. Ros kort ved korrekte svar og forklar hvad der mangler ved forkerte.'
+        ],
+        [
+            'role' => 'user',
+            'content' => sprintf(
+                "Opgave: %s\nForventet løsningsidé: %s\nFaglærerens forklaring: %s\nElevens svar: %s\n\nVurder om elevens svar matcher løsningen.",
+                $prompt,
+                $expected,
+                $explanation,
+                $answer
+            )
+        ]
+    ]
+];
+
+$ch = curl_init('https://api.openai.com/v1/chat/completions');
+$curlOptions = [
+    CURLOPT_POST => true,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER => [
+        'Content-Type: application/json',
+        'Authorization: Bearer ' . $apiKey,
+    ],
+    CURLOPT_POSTFIELDS => json_encode($requestBody, JSON_UNESCAPED_UNICODE),
+];
+
+if ($caBundle) {
+    $curlOptions[CURLOPT_CAINFO] = $caBundle;
+}
+
+curl_setopt_array($ch, $curlOptions);
+$response = curl_exec($ch);
+if ($response === false) {
+    $errorMessage = curl_error($ch) ?: 'Ukendt fejl ved kald til OpenAI.';
+    curl_close($ch);
+    respond(['error' => $errorMessage], 502);
+}
+
+$statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+$decoded = json_decode($response, true);
+if ($statusCode >= 400) {
+    $message = is_array($decoded) ? ($decoded['error']['message'] ?? 'OpenAI returnerede en fejl.') : 'OpenAI returnerede en fejl.';
+    respond(['error' => $message], $statusCode);
+}
+
+if (!is_array($decoded)) {
+    respond(['error' => 'Uventet svar fra OpenAI.'], 502);
+}
+
+$content = (string) ($decoded['choices'][0]['message']['content'] ?? '');
+if ($content === '') {
+    respond(['error' => 'OpenAI gav ikke noget indhold i svaret.'], 502);
+}
+
+$result = json_decode($content, true);
+if (!is_array($result) || !isset($result['status'])) {
+    // Forsøg at tolke tekstligt svar
+    $status = stripos($content, 'korrekt') !== false ? 'correct' : 'incorrect';
+    $result = [
+        'status' => $status,
+        'feedback' => trim($content)
+    ];
+}
+
+$status = in_array($result['status'], ['correct', 'incorrect'], true) ? $result['status'] : 'incorrect';
+$feedback = isset($result['feedback']) ? trim((string) $result['feedback']) : '';
+
+respond([
+    'status' => $status,
+    'feedback' => $feedback !== '' ? $feedback : ($status === 'correct' ? 'Godt arbejde – svaret matcher løsningen.' : 'Svaret matcher ikke helt forventningen. Tjek dine beregninger igen.')
+]);

--- a/api/check-subnet-task.php
+++ b/api/check-subnet-task.php
@@ -25,6 +25,13 @@ function findConfigFile(): array
     $candidates = [];
     $checked = [];
 
+    $envPath = getenv('CONFIG_PATH');
+    if (is_string($envPath) && $envPath !== '') {
+        $candidates[] = $envPath;
+        $candidates[] = __DIR__ . '/' . ltrim($envPath, '/\\');
+        $candidates[] = dirname(__DIR__) . '/' . ltrim($envPath, '/\\');
+    }
+
     $envFile = getenv('CONFIG_FILE');
     if (is_string($envFile) && $envFile !== '') {
         $candidates[] = $envFile;
@@ -40,6 +47,37 @@ function findConfigFile(): array
     }
 
     $bases = [__DIR__, dirname(__DIR__), dirname(__DIR__, 2), dirname(__DIR__, 3)];
+
+    $docRoots = [];
+    $docRoot = $_SERVER['DOCUMENT_ROOT'] ?? '';
+    if (is_string($docRoot) && $docRoot !== '') {
+        $docRoots[] = $docRoot;
+    }
+    $contextRoot = $_SERVER['CONTEXT_DOCUMENT_ROOT'] ?? '';
+    if (is_string($contextRoot) && $contextRoot !== '' && $contextRoot !== $docRoot) {
+        $docRoots[] = $contextRoot;
+    }
+    $scriptFilename = $_SERVER['SCRIPT_FILENAME'] ?? '';
+    if (is_string($scriptFilename) && $scriptFilename !== '') {
+        $docRoots[] = dirname($scriptFilename);
+    }
+    $scriptDirName = $_SERVER['SCRIPT_NAME'] ?? '';
+    if (is_string($scriptDirName) && $scriptDirName !== '' && is_string($docRoot) && $docRoot !== '') {
+        $joined = rtrim($docRoot, "\\/") . '/' . ltrim(dirname($scriptDirName), '/\\');
+        $docRoots[] = $joined;
+    }
+
+    foreach ($docRoots as $root) {
+        if (!is_string($root) || $root === '') {
+            continue;
+        }
+        $root = rtrim($root, "\\/");
+        if ($root === '') {
+            continue;
+        }
+        $bases[] = $root;
+    }
+
     foreach ($bases as $base) {
         if (!is_string($base) || $base === '') {
             continue;
@@ -259,7 +297,7 @@ $requestBody = [
     'messages' => [
         [
             'role' => 'system',
-            'content' => 'Du er en hjælpsom underviser i subnetting. Du skal svare med JSON på formen {"status":"correct|incorrect","feedback":"kort forklaring på dansk"}. Ros kort ved korrekte svar og forklar hvad der mangler ved forkerte.'
+            'content' => 'Du er en hjælpsom underviser i subnetting. Svar altid med JSON på formen {"status":"correct|incorrect","feedback":"tekst"}. "feedback" skal være 2-3 korte sætninger på dansk. Hvis svaret er korrekt: ros kort og forklar hvorfor løsningen er rigtig. Hvis svaret er forkert: giv konkrete hints til, hvordan eleven kan finde svaret, fx hvilke formler eller intervaller der skal bruges, men afslør aldrig den præcise adresse eller det nøjagtige tal. Nævn aldrig direkte den forventede løsning.'
         ],
         [
             'role' => 'user',
@@ -331,6 +369,29 @@ if (!is_array($result) || !isset($result['status'])) {
 
 $status = in_array($result['status'], ['correct', 'incorrect'], true) ? $result['status'] : 'incorrect';
 $feedback = isset($result['feedback']) ? trim((string) $result['feedback']) : '';
+
+if ($status === 'incorrect' && $expected !== '') {
+    $pattern = '/' . preg_quote($expected, '/') . '/iu';
+    $feedback = preg_replace($pattern, '[skjult]', $feedback);
+}
+
+$feedback = trim($feedback);
+
+if ($status === 'correct') {
+    if ($feedback === '') {
+        $feedback = 'Godt arbejde – svaret matcher løsningen.';
+    }
+    if (stripos($feedback, 'godt arbejde') !== 0 && stripos($feedback, 'flot arbejde') !== 0) {
+        $feedback = 'Godt arbejde! ' . $feedback;
+    }
+} else {
+    if ($feedback === '') {
+        $feedback = 'Gennemgå trin for trin, hvordan subnettet beregnes, og dobbelttjek dine mellemregninger.';
+    }
+    if (stripos($feedback, 'elevens svar') !== 0) {
+        $feedback = 'Elevens svar er ikke korrekt endnu. ' . $feedback;
+    }
+}
 
 respond([
     'status' => $status,

--- a/api/explain-term.php
+++ b/api/explain-term.php
@@ -1,0 +1,320 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+
+function respond(array $payload, int $status = 200): void
+{
+    http_response_code($status);
+    echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function decodePayload(string $raw): array
+{
+    $data = json_decode($raw, true);
+    if (!is_array($data)) {
+        respond(['error' => 'Ugyldigt JSON-format.'], 400);
+    }
+
+    return $data;
+}
+
+function findConfigFile(): array
+{
+    $candidates = [];
+    $checked = [];
+
+    $envPath = getenv('CONFIG_PATH');
+    if (is_string($envPath) && $envPath !== '') {
+        $candidates[] = $envPath;
+        $candidates[] = __DIR__ . '/' . ltrim($envPath, '/\\');
+        $candidates[] = dirname(__DIR__) . '/' . ltrim($envPath, '/\\');
+    }
+
+    $envFile = getenv('CONFIG_FILE');
+    if (is_string($envFile) && $envFile !== '') {
+        $candidates[] = $envFile;
+        $candidates[] = __DIR__ . '/' . ltrim($envFile, '/\\');
+        $candidates[] = dirname(__DIR__) . '/' . ltrim($envFile, '/\\');
+    }
+
+    $envDir = getenv('CONFIG_DIR');
+    if (is_string($envDir) && $envDir !== '') {
+        $dir = rtrim($envDir, "\\/");
+        $candidates[] = $dir . '/config.php';
+        $candidates[] = $dir . '/config.phg';
+    }
+
+    $bases = [__DIR__, dirname(__DIR__), dirname(__DIR__, 2), dirname(__DIR__, 3)];
+
+    $docRoots = [];
+    $docRoot = $_SERVER['DOCUMENT_ROOT'] ?? '';
+    if (is_string($docRoot) && $docRoot !== '') {
+        $docRoots[] = $docRoot;
+    }
+    $contextRoot = $_SERVER['CONTEXT_DOCUMENT_ROOT'] ?? '';
+    if (is_string($contextRoot) && $contextRoot !== '' && $contextRoot !== $docRoot) {
+        $docRoots[] = $contextRoot;
+    }
+    $scriptFilename = $_SERVER['SCRIPT_FILENAME'] ?? '';
+    if (is_string($scriptFilename) && $scriptFilename !== '') {
+        $docRoots[] = dirname($scriptFilename);
+    }
+    $scriptDirName = $_SERVER['SCRIPT_NAME'] ?? '';
+    if (is_string($scriptDirName) && $scriptDirName !== '' && is_string($docRoot) && $docRoot !== '') {
+        $joined = rtrim($docRoot, "\\/") . '/' . ltrim(dirname($scriptDirName), '/\\');
+        $docRoots[] = $joined;
+    }
+
+    foreach ($docRoots as $root) {
+        if (!is_string($root) || $root === '') {
+            continue;
+        }
+        $root = rtrim($root, "\\/");
+        if ($root === '') {
+            continue;
+        }
+        $bases[] = $root;
+    }
+
+    foreach ($bases as $base) {
+        if (!is_string($base) || $base === '') {
+            continue;
+        }
+        $base = rtrim($base, "\\/");
+        if ($base === '') {
+            continue;
+        }
+        $candidates[] = $base . '/config.php';
+        $candidates[] = $base . '/Config.php';
+        $candidates[] = $base . '/config/config.php';
+        $candidates[] = $base . '/config/config.phg';
+        $candidates[] = $base . '/Config/config.php';
+        $candidates[] = $base . '/Config/config.phg';
+    }
+
+    $seen = [];
+    foreach ($candidates as $candidate) {
+        if (!$candidate) {
+            continue;
+        }
+        $normalized = preg_replace('#[\\/]+#', '/', $candidate);
+        if (isset($seen[$normalized])) {
+            continue;
+        }
+        $seen[$normalized] = true;
+        $checked[] = $normalized;
+        if (is_readable($candidate) && !is_dir($candidate)) {
+            return [$candidate, dirname($candidate), $checked];
+        }
+    }
+
+    return [null, null, $checked];
+}
+
+function loadCredentials(): array
+{
+    $apiKey = null;
+    $caBundle = null;
+    $baseUrl = 'https://api.openai.com/v1';
+    $model = 'gpt-4o-mini';
+    $timeout = 30;
+
+    [$configPath, $configDir, $checkedPaths] = findConfigFile();
+
+    if ($configPath) {
+        $loaded = require $configPath;
+        if (is_string($loaded)) {
+            $apiKey = trim($loaded);
+        } elseif (is_array($loaded)) {
+            if (isset($loaded['OPENAI_API_KEY'])) {
+                $apiKey = trim((string) $loaded['OPENAI_API_KEY']);
+            }
+            if (isset($loaded['CA_BUNDLE'])) {
+                $candidate = trim((string) $loaded['CA_BUNDLE']);
+                if ($candidate !== '') {
+                    if (!is_readable($candidate) && $configDir) {
+                        $relative = $configDir . '/' . ltrim($candidate, '/\\');
+                        if (is_readable($relative)) {
+                            $candidate = $relative;
+                        }
+                    }
+                    if (is_readable($candidate)) {
+                        $caBundle = $candidate;
+                    }
+                }
+            }
+            if (isset($loaded['OPENAI_BASE'])) {
+                $trimmedBase = trim((string) $loaded['OPENAI_BASE']);
+                if ($trimmedBase !== '') {
+                    $baseUrl = $trimmedBase;
+                }
+            }
+            if (isset($loaded['OPENAI_MODEL'])) {
+                $trimmedModel = trim((string) $loaded['OPENAI_MODEL']);
+                if ($trimmedModel !== '') {
+                    $model = $trimmedModel;
+                }
+            }
+            if (isset($loaded['TIMEOUT'])) {
+                $timeout = max(0, (int) $loaded['TIMEOUT']);
+            } elseif (isset($loaded['OPENAI_TIMEOUT'])) {
+                $timeout = max(0, (int) $loaded['OPENAI_TIMEOUT']);
+            }
+        }
+    }
+
+    if (!$caBundle && $configDir) {
+        $defaultCa = $configDir . '/cacert.pem';
+        if (is_readable($defaultCa)) {
+            $caBundle = $defaultCa;
+        }
+    }
+
+    if (!$apiKey) {
+        $apiKey = getenv('OPENAI_API_KEY') ?: '';
+    }
+
+    $envBase = getenv('OPENAI_BASE');
+    if (is_string($envBase) && trim($envBase) !== '') {
+        $baseUrl = trim($envBase);
+    }
+
+    $envModel = getenv('OPENAI_MODEL');
+    if (is_string($envModel) && trim($envModel) !== '') {
+        $model = trim($envModel);
+    }
+
+    $envTimeout = getenv('OPENAI_TIMEOUT');
+    if (is_string($envTimeout) && trim($envTimeout) !== '') {
+        $timeout = max(0, (int) $envTimeout);
+    }
+
+    $envCa = getenv('OPENAI_CA_BUNDLE');
+    if (!$caBundle && is_string($envCa) && trim($envCa) !== '') {
+        $candidate = trim($envCa);
+        if (!is_readable($candidate) && $configDir) {
+            $relative = $configDir . '/' . ltrim($candidate, '/\\');
+            if (is_readable($relative)) {
+                $candidate = $relative;
+            }
+        }
+        if (is_readable($candidate)) {
+            $caBundle = $candidate;
+        }
+    }
+
+    return [
+        'apiKey' => $apiKey ?: '',
+        'caBundle' => $caBundle,
+        'baseUrl' => $baseUrl,
+        'model' => $model,
+        'timeout' => $timeout,
+        'configPath' => $configPath,
+        'checkedPaths' => $checkedPaths,
+    ];
+}
+
+$rawInput = file_get_contents('php://input');
+if ($rawInput === false) {
+    respond(['error' => 'Kunne ikke læse forespørgslen.'], 400);
+}
+
+$payload = decodePayload($rawInput);
+$term = isset($payload['term']) ? trim((string) $payload['term']) : '';
+$context = isset($payload['context']) ? trim((string) $payload['context']) : '';
+
+if ($term === '') {
+    respond(['error' => 'Angiv et begreb, der skal forklares.'], 400);
+}
+
+$credentials = loadCredentials();
+if ($credentials['apiKey'] === '') {
+    $searched = $credentials['checkedPaths'] ?? [];
+    $hint = '';
+    if (!empty($credentials['configPath'])) {
+        $hint = ' Forsøgte at bruge: ' . $credentials['configPath'] . '.';
+    } elseif (!empty($searched)) {
+        $preview = array_slice($searched, 0, 5);
+        if (count($searched) > 5) {
+            $preview[] = '…';
+        }
+        $hint = ' Søgte i: ' . implode(', ', $preview) . '.';
+    }
+
+    respond([
+        'error' => 'Serveren mangler OpenAI API-nøglen. Tjek config/config.php (feltet OPENAI_API_KEY) eller miljøvariablen OPENAI_API_KEY.' . $hint
+    ], 500);
+}
+
+$endpoint = rtrim($credentials['baseUrl'], '/') . '/chat/completions';
+
+$requestBody = [
+    'model' => $credentials['model'] !== '' ? $credentials['model'] : 'gpt-4o-mini',
+    'temperature' => 0.35,
+    'max_tokens' => 320,
+    'messages' => [
+        [
+            'role' => 'system',
+            'content' => 'Du er en engageret IT-underviser på et Grundforløb på Techcollege. Forklar danske elever et fagligt begreb om netværk med venlig tone, korte afsnit og konkrete eksempler. Brug gerne punktopstilling eller små øvelser. Afslut med en opfordring til, hvad eleven kan gøre nu. Giv aldrig eksamenssvar eller fulde facits.'
+        ],
+        [
+            'role' => 'user',
+            'content' => sprintf(
+                "Begreb: %s\nKontekst: %s\nSkriv på dansk, maks 140 ord.",
+                $term,
+                $context !== '' ? $context : 'Ingen ekstra kontekst angivet.'
+            )
+        ]
+    ],
+];
+
+$ch = curl_init($endpoint);
+$curlOptions = [
+    CURLOPT_POST => true,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER => [
+        'Content-Type: application/json',
+        'Authorization: Bearer ' . $credentials['apiKey'],
+    ],
+    CURLOPT_POSTFIELDS => json_encode($requestBody, JSON_UNESCAPED_UNICODE),
+];
+
+if ($credentials['caBundle']) {
+    $curlOptions[CURLOPT_CAINFO] = $credentials['caBundle'];
+}
+
+if ($credentials['timeout'] > 0) {
+    $curlOptions[CURLOPT_TIMEOUT] = $credentials['timeout'];
+}
+
+curl_setopt_array($ch, $curlOptions);
+$response = curl_exec($ch);
+if ($response === false) {
+    $errorMessage = curl_error($ch) ?: 'Ukendt fejl ved kald til OpenAI.';
+    curl_close($ch);
+    respond(['error' => $errorMessage], 502);
+}
+
+$statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+$decoded = json_decode($response, true);
+if ($statusCode >= 400) {
+    $message = is_array($decoded) ? ($decoded['error']['message'] ?? 'OpenAI returnerede en fejl.') : 'OpenAI returnerede en fejl.';
+    respond(['error' => $message], $statusCode);
+}
+
+if (!is_array($decoded)) {
+    respond(['error' => 'Uventet svar fra OpenAI.'], 502);
+}
+
+$explanation = trim((string) ($decoded['choices'][0]['message']['content'] ?? ''));
+if ($explanation === '') {
+    respond(['error' => 'OpenAI gav ikke noget indhold i svaret.'], 502);
+}
+
+respond([
+    'explanation' => $explanation,
+]);

--- a/assets/app.js
+++ b/assets/app.js
@@ -451,7 +451,7 @@ function renderStep1() {
 
       return `
         <div class="relative border-4 ${subnet.panelClasses} rounded-2xl bg-gradient-to-b overflow-hidden min-h-[420px]">
-          <div class="absolute top-4 left-4 bg-white/90 border border-slate-200 rounded-lg px-4 py-2 shadow-sm z-30">
+          <div class="absolute top-4 left-4 bg-white/95 border border-slate-200 rounded-lg px-4 py-2 shadow-sm z-30">
             <p class="font-bold text-gray-800 text-sm">${subnet.title}</p>
             <p class="text-xs text-gray-600">${subnet.mask}</p>
             <p class="text-xs text-gray-500">${subnet.hostsLabel}</p>
@@ -476,9 +476,6 @@ function renderStep1() {
           <div class="absolute left-0 right-0 bottom-6 text-center z-30">
             <span class="inline-flex items-center gap-1 ${subnet.badgeClasses} px-3 py-1 rounded-full text-xs font-semibold">📶 Lokalt broadcast</span>
           </div>
-          <div class="router-gate-note ${subnet.id === 1 ? 'left' : 'right'}">
-            <span>Routeren afviser broadcast til det andet subnet</span>
-          </div>
         </div>
       `;
     })
@@ -486,27 +483,28 @@ function renderStep1() {
 
   visualizationEl.innerHTML = `
     <div class="relative min-h-[560px]">
-      <div class="absolute left-1/2 -translate-x-1/2 top-6 z-40 text-center">
+      <div class="absolute left-1/2 -translate-x-1/2 top-4 z-40 text-center router-stack">
         <div class="bg-slate-900 text-white border-4 border-slate-700 rounded-2xl px-8 py-4 shadow-2xl">
           <p class="text-sm font-bold tracking-[0.45em]">ROUTER</p>
           <div class="flex gap-1 justify-center mt-2">${routerPorts}</div>
         </div>
-        <div class="mt-2 flex flex-col items-center gap-1">
-          <span class="inline-block bg-white/90 text-xs font-semibold text-slate-600 px-3 py-1 rounded-full shadow-sm">Forbinder subnettene</span>
-          <span class="inline-block bg-emerald-50/90 text-[11px] font-semibold text-emerald-700 px-3 py-1 rounded-full shadow-sm">Router stopper broadcast til andre LAN</span>
+        <div class="router-bridge-badge">Forbinder subnettene</div>
+        <div id="router-stop-indicator" class="router-stop-label">
+          <span class="router-stop-icon">🚫</span>
+          <span>Router stopper broadcast til andre LAN</span>
         </div>
       </div>
 
       <svg class="absolute inset-0 w-full h-full pointer-events-none router-link-layer" viewBox="0 0 100 100" preserveAspectRatio="none">
-        <path id="router-path-left" d="M50 26 C44 32 38 36 34 42" stroke="#14b8a6" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.75" fill="none"></path>
-        <path id="router-path-right" d="M50 26 C56 32 62 36 66 42" stroke="#38bdf8" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.75" fill="none"></path>
-        <circle cx="34" cy="42" r="1.5" fill="#0f766e" fill-opacity="0.8"></circle>
-        <circle cx="66" cy="42" r="1.5" fill="#0369a1" fill-opacity="0.8"></circle>
-        <g class="router-stop-marker" transform="translate(34 42)">
+        <path id="router-path-left" d="M50 24 C44 31 38 36 33 43" stroke="#14b8a6" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.78" fill="none"></path>
+        <path id="router-path-right" d="M50 24 C56 31 62 36 67 43" stroke="#38bdf8" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.78" fill="none"></path>
+        <circle cx="33" cy="43" r="1.4" fill="#0f766e" fill-opacity="0.85"></circle>
+        <circle cx="67" cy="43" r="1.4" fill="#0369a1" fill-opacity="0.85"></circle>
+        <g class="router-stop-marker" transform="translate(33 43)">
           <circle r="4.1"></circle>
           <text x="0" y="1.5">🚫</text>
         </g>
-        <g class="router-stop-marker" transform="translate(66 42)">
+        <g class="router-stop-marker" transform="translate(67 43)">
           <circle r="4.1"></circle>
           <text x="0" y="1.5">🚫</text>
         </g>
@@ -514,13 +512,6 @@ function renderStep1() {
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 pt-40">
         ${panels}
-      </div>
-
-      <div class="router-stop-banner left">
-        <span>🚫 Routeren stopper broadcast videre mod Subnet 2</span>
-      </div>
-      <div class="router-stop-banner right">
-        <span>🚫 Ingen broadcast sendes videre til Subnet 1</span>
       </div>
     </div>
   `;
@@ -539,13 +530,15 @@ function renderStep1() {
   setupRouterTraffic({
     pathId: 'router-path-left',
     color: '#0f766e',
-    burstColor: '#14b8a6'
+    burstColor: '#14b8a6',
+    indicatorId: 'router-stop-indicator'
   });
 
   setupRouterTraffic({
     pathId: 'router-path-right',
     color: '#0369a1',
-    burstColor: '#38bdf8'
+    burstColor: '#38bdf8',
+    indicatorId: 'router-stop-indicator'
   });
 }
 
@@ -1111,7 +1104,7 @@ function renderVisualization() {
   }
 }
 
-function setupRouterTraffic({ pathId, color, burstColor }) {
+function setupRouterTraffic({ pathId, color, burstColor, indicatorId }) {
   const path = document.getElementById(pathId);
   if (!path) {
     return;
@@ -1124,6 +1117,8 @@ function setupRouterTraffic({ pathId, color, burstColor }) {
 
   const pathLength = path.getTotalLength();
   const activePackets = [];
+  const indicator = indicatorId ? document.getElementById(indicatorId) : null;
+  let activeIndicatorBursts = 0;
 
   const spawnPacket = () => {
     const packet = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
@@ -1182,6 +1177,19 @@ function setupRouterTraffic({ pathId, color, burstColor }) {
         burst.setAttribute('stroke-width', '1.4');
         svg.appendChild(burst);
 
+        if (indicator) {
+          activeIndicatorBursts += 1;
+          indicator.classList.add('router-stop-label--active');
+          indicator.classList.add('router-stop-label--pulse');
+          setTimeout(() => {
+            activeIndicatorBursts = Math.max(activeIndicatorBursts - 1, 0);
+            indicator.classList.remove('router-stop-label--pulse');
+            if (activeIndicatorBursts === 0) {
+              indicator.classList.remove('router-stop-label--active');
+            }
+          }, 700);
+        }
+
         setTimeout(() => {
           if (burst.parentNode) {
             burst.parentNode.removeChild(burst);
@@ -1204,6 +1212,11 @@ function setupRouterTraffic({ pathId, color, burstColor }) {
         burst.parentNode.removeChild(burst);
       }
     });
+    if (indicator) {
+      activeIndicatorBursts = 0;
+      indicator.classList.remove('router-stop-label--pulse');
+      indicator.classList.remove('router-stop-label--active');
+    }
   };
 
   routerTrafficGenerators.push(generator);

--- a/assets/app.js
+++ b/assets/app.js
@@ -582,96 +582,112 @@ function renderStep0() {
           <p class="text-sm text-gray-700">"Vi har et problem! Alt for meget broadcast-trafik gennem switchen. Vi skal opdele netværket i mindre subnets!"</p>
         </div>
       </div>
-      <article class="tutorial-panel tutorial-panel--stacked">
-        <header class="tutorial-panel__header">
-          <p class="tutorial-panel__kicker">Grundforløb – lektion 1</p>
-          <h2 class="tutorial-panel__title">Introduktion til subnetting</h2>
-        </header>
-        <p>
-          I dag arbejder vi sammen om at forstå, hvorfor vi opdeler et netværk. Forestil jer, at hele værkstedet kun er forbundet via ét
-          <button type="button" class="term-button" data-term="LAN" data-context="Definér begrebet Local Area Network for elever på et grundforløb og giv et letforståeligt eksempel.">LAN</button>.
-          Når nogen sender en besked, hører alle den. Det kan være hyggeligt, men det bliver hurtigt larm. Subnetting er teknikken, der hjælper os med at styre den larm.
-        </p>
-        <div class="tutorial-scroll">
-          <section class="tutorial-section">
-            <h3>1. Hvad er en IP-adresse?</h3>
+      <article class="tutorial-panel tutorial-panel--split">
+        <div class="tutorial-intro">
+          <header class="tutorial-panel__header">
+            <p class="tutorial-panel__kicker">Grundforløb – lektion 1</p>
+            <h2 class="tutorial-panel__title">Introduktion til subnetting</h2>
+          </header>
+          <div class="tutorial-intro__content">
             <p>
-              Hver computer får en unik <button type="button" class="term-button" data-term="IP-adresse" data-context="Forklar hvad en IPv4-adresse er, hvorfor den har fire tal, og hvordan elever kan læse den.">IP-adresse</button>, fx
-              <span class="tutorial-highlight">192.168.1.23</span>. De første tal fortæller, hvilket område vi er i, og de sidste tal peger på den konkrete enhed. Vi kalder det
-              <button type="button" class="term-button" data-term="Netværksdel" data-context="Forklar forskellen på netværksdel og hostdel i et sprog der passer til grundforløbs-elever.">netværksdel</button>
-              og <button type="button" class="term-button" data-term="Hostdel" data-context="Forklar hvad hostdelen er i en IPv4-adresse og hvorfor den begrænser hvor mange enheder der kan være i et subnet.">hostdel</button>.
+              Brug denne trin-for-trin guide som din undervisningsmakker. Vi starter med en fælles forståelse af, hvorfor vi skal dele netværket op, og hvilke begreber du skal kunne forklare efter lektionen.
             </p>
-            <ul class="tutorial-list">
-              <li><strong>Netværksdel:</strong> hvem er med i gruppen?</li>
-              <li><strong>Hostdel:</strong> hvilken elev i gruppen taler vi med?</li>
-              <li><strong>Eksempel:</strong> 192.168.1.<em>x</em> – de tre første tal er fælles, det sidste <em>x</em> skifter mellem 1 og 254.</li>
+            <ul class="tutorial-intro__objectives">
+              <li>Læse en <button type="button" class="term-button" data-term="IP-adresse" data-context="Forklar hvad en IPv4-adresse er, hvorfor den har fire tal, og hvordan elever kan læse den.">IP-adresse</button> og skelne mellem <button type="button" class="term-button" data-term="Netværksdel" data-context="Forklar forskellen på netværksdel og hostdel i et sprog der passer til grundforløbs-elever.">netværksdel</button> og <button type="button" class="term-button" data-term="Hostdel" data-context="Forklar hvad hostdelen er i en IPv4-adresse og hvorfor den begrænser hvor mange enheder der kan være i et subnet.">hostdel</button>.</li>
+              <li>Forklare hvorfor for meget <button type="button" class="term-button" data-term="Broadcast" data-context="Forklar hvad broadcast betyder i et LAN, hvorfor det kan skabe støj, og hvordan det opleves af nye elever.">broadcast</button>-trafik gør hverdagen langsom.</li>
+              <li>Bruge en <button type="button" class="term-button" data-term="Subnetmaske" data-context="Forklar hvad en subnetmaske er, hvordan man læser den, og hvorfor den er vigtig når man opdeler netværk.">subnetmaske</button> til at låne bits og skabe mindre netværk.</li>
             </ul>
-          </section>
-          <section class="tutorial-section">
-            <h3>2. Hvorfor bliver der larm?</h3>
-            <p>
-              Når en enhed sender en <button type="button" class="term-button" data-term="Broadcast" data-context="Forklar hvad broadcast betyder i et LAN, hvorfor det kan skabe støj, og hvordan det opleves af nye elever.">broadcast</button>,
-              spørger den: “Er du der?” til alle på én gang. På små hold er det fint, men med 24 pc'er, printere og IoT-enheder betyder det mange afbrydelser.
-            </p>
-            <div class="tutorial-callout">
-              <p><strong>Konsekvens:</strong> Filer åbner langsomt, og fejlsøgning bliver svært, fordi alle ser hinandens beskeder.</p>
-              <p><strong>Observation:</strong> Kig på animationen ovenfor og bemærk, hvordan hver rød pakke rammer alle maskiner.</p>
-            </div>
-          </section>
-          <section class="tutorial-section">
-            <h3>3. Hvad gør subnetting?</h3>
-            <p>
-              Subnetting betyder, at vi deler hostdelen op i mindre grupper ved hjælp af en
-              <button type="button" class="term-button" data-term="Subnetmaske" data-context="Forklar hvad en subnetmaske er, hvordan man læser den, og hvorfor den er vigtig når man opdeler netværk.">subnetmaske</button>.
-              Vi “låner” bits fra hostdelen til netværksdelen, så vi får flere grupper men færre pladser i hver gruppe.
-            </p>
-            <ol class="tutorial-steps">
-              <li>Start med et <span class="tutorial-highlight">/24</span>-netværk (255.255.255.0) – 254 mulige enheder.</li>
-              <li>Lån én bit → <span class="tutorial-highlight">/25</span> (255.255.255.128) – nu har vi to grupper med plads til 126 enheder hver.</li>
-              <li>Hver gruppe får sin egen <button type="button" class="term-button" data-term="Gateway" data-context="Forklar gateway-begrebet for en ny elev og hvorfor den er nødvendig når vi forbinder flere subnets.">gateway</button> for at tale med resten af verden.</li>
-            </ol>
-          </section>
-          <section class="tutorial-section">
-            <h3>4. Eksempel fra vores værksted</h3>
-            <p>
-              Vi deler 24 pc'er i to hold:
-            </p>
-            <ul class="tutorial-list">
-              <li><strong>Subnet 1:</strong> 192.168.1.0 – 192.168.1.127 til teori-lokalet.</li>
-              <li><strong>Subnet 2:</strong> 192.168.1.128 – 192.168.1.255 til værkstedet.</li>
-              <li>Begge subnets taler med en fælles router, men <em>broadcasts</em> bliver i deres egen gruppe.</li>
-            </ul>
-            <p>
-              Resultatet er roligere netværk, hurtigere svar fra serverne og lettere fejlsøgning.
-            </p>
-          </section>
-          <section class="tutorial-section">
-            <h3>5. Sådan øver vi os</h3>
-            <p>
-              Følg disse aktiviteter i klassen:
-            </p>
-            <ol class="tutorial-steps">
-              <li>Notér hvilke enheder der er vigtige i jeres lokale. Hvor mange adresser skal de bruge?</li>
-              <li>Brug beregneren i trin 5 til at finde et subnet, der passer til jeres tal.</li>
-              <li>Sammenlign jeres svar med makkeren og forklar forskellen.</li>
-              <li>Test viden i opgavebanken på trin 6 – klik på “Vis forklaring”, hvis I går i stå.</li>
-            </ol>
-          </section>
-          <section class="tutorial-section">
-            <h3>6. Opsummering før vi går videre</h3>
-            <p>
-              Subnetting hjælper os med at holde styr på trafikken, beskytte udstyr og skabe et godt læringsmiljø. Klik på fagordene, hvis noget er uklart – AI-assistenten giver en kort forklaring målrettet jer som Grundforløbshold.
-            </p>
-            <p>
-              Når I er klar, går vi videre til næste trin og ser, hvordan netværket ændrer sig i praksis.
-            </p>
-          </section>
+            <section class="tutorial-intro__tips">
+              <h3 class="tutorial-intro__heading">Sådan bruger du materialet</h3>
+              <ol>
+                <li>Se animationen ovenfor og notér, hvad der sker, når alle er på samme <button type="button" class="term-button" data-term="LAN" data-context="Definér begrebet Local Area Network for elever på et grundforløb og giv et letforståeligt eksempel.">LAN</button>.</li>
+                <li>Læs hvert afsnit i tutorialen til højre. Klik på fagordene, hvis du vil have en ekstra forklaring fra AI-assistenten.</li>
+                <li>Efter lektionen skal du kunne udfylde eksempler og opgaver uden hjælp – brug derfor noterne aktivt.</li>
+              </ol>
+            </section>
+          </div>
         </div>
-        <footer class="tutorial-panel__footer">
-          <p>
-            Spørgsmål er velkomne! Jo bedre vi forstår grundideen, desto nemmere bliver resten af forløbet.
-          </p>
-        </footer>
+        <div class="tutorial-body">
+          <div class="tutorial-body__lead">
+            <p>
+              Følg kapitlerne herunder i rækkefølge. De er bygget til et grundforløbshold, så vi tager små skridt og kobler hele tiden tilbage til praksis i værkstedet.
+            </p>
+          </div>
+          <div class="tutorial-scroll">
+            <section class="tutorial-section">
+              <h3>Trin 1 – Læs en IP-adresse</h3>
+              <p>
+                Hver computer får en adresse med fire tal, fx <span class="tutorial-highlight">192.168.1.23</span>. De første tre tal viser hvilket område vi er i, mens det sidste tal peger på den konkrete enhed.
+              </p>
+              <ul class="tutorial-list">
+                <li><strong>Netværksdel:</strong> fortæller hvilken gruppe enheden tilhører.</li>
+                <li><strong>Hostdel:</strong> viser hvilken deltager i gruppen vi taler med.</li>
+                <li>Kan du udpege netværksdelen i dit eget klasse-lokale netværk?</li>
+              </ul>
+            </section>
+            <section class="tutorial-section">
+              <h3>Trin 2 – Spot netværksstøjen</h3>
+              <p>
+                Når en enhed sender en <button type="button" class="term-button" data-term="Broadcast" data-context="Forklar hvad broadcast betyder i et LAN, hvorfor det kan skabe støj, og hvordan det opleves af nye elever.">broadcast</button>, spørger den alle: “Er du der?”. På små hold er det fint, men i et værksted med pc'er, printere og IoT-enheder skaber det kø og afbrydelser.
+              </p>
+              <div class="tutorial-callout">
+                <p><strong>Prøv selv:</strong> Peg på animationen, hvor du ser rød trafik. Hvilke enheder bliver ramt, selv om beskeden ikke er til dem?</p>
+                <p><strong>Konsekvens:</strong> Login kan tage længere tid, og fejlfinding bliver svært, fordi alle ser hinandens beskeder.</p>
+              </div>
+            </section>
+            <section class="tutorial-section">
+              <h3>Trin 3 – Brug subnetmasken som værktøj</h3>
+              <p>
+                Vi deler hostdelen op med en <button type="button" class="term-button" data-term="Subnetmaske" data-context="Forklar hvad en subnetmaske er, hvordan man læser den, og hvorfor den er vigtig når man opdeler netværk.">subnetmaske</button>. Det svarer til at lave flere grupper i et klasselokale, så hver gruppe kan arbejde i fred.
+              </p>
+              <ol class="tutorial-steps">
+                <li>Start i et <span class="tutorial-highlight">/24</span>-netværk (255.255.255.0) med plads til 254 enheder.</li>
+                <li>Lån én bit → <span class="tutorial-highlight">/25</span> (255.255.255.128), så vi får to mindre grupper med 126 mulige enheder i hver.</li>
+                <li>Tilføj en <button type="button" class="term-button" data-term="Gateway" data-context="Forklar gateway-begrebet for en ny elev og hvorfor den er nødvendig når vi forbinder flere subnets.">gateway</button>, der kan sende trafik videre mellem grupperne.</li>
+              </ol>
+            </section>
+            <section class="tutorial-section">
+              <h3>Trin 4 – Arbejdseksempel fra værkstedet</h3>
+              <p>
+                Vi deler 24 pc'er i to hold, så teorilokalet ikke hører alt fra værkstedet.
+              </p>
+              <ul class="tutorial-list">
+                <li><strong>Subnet 1:</strong> 192.168.1.0 – 192.168.1.127 til teorilokalet.</li>
+                <li><strong>Subnet 2:</strong> 192.168.1.128 – 192.168.1.255 til værkstedet.</li>
+                <li>Routeren binder subnets sammen, men broadcast bliver i egen gruppe.</li>
+              </ul>
+              <p>
+                Resultatet er hurtigere svar fra serverne og mere ro omkring de enkelte maskiner.
+              </p>
+            </section>
+            <section class="tutorial-section">
+              <h3>Trin 5 – Øv teknikken</h3>
+              <p>
+                Brug aktiviteterne her for at gøre subnetting til en færdighed:
+              </p>
+              <ol class="tutorial-steps">
+                <li>Lav en liste over udstyr i dit lokale. Hvor mange adresser kræver hver gruppe?</li>
+                <li>Test forskellige netværksklasser i beregneren på trin 5 og vurder, hvornår du løber tør for adresser.</li>
+                <li>Sammenlign dine valg med en makker og diskuter fordele og ulemper.</li>
+                <li>Arbejd med opgaverne i trin 6 – klik på “Vis forklaring”, når du vil se en detaljeret løsning.</li>
+              </ol>
+            </section>
+            <section class="tutorial-section">
+              <h3>Trin 6 – Opsummering før næste emne</h3>
+              <p>
+                Subnetting hjælper os med at styre trafikken, beskytte udstyr og få en klasse, der kan arbejde effektivt på samme tid. Brug fagord-knapperne, hvis noget er uklart – AI'en giver en kort, målrettet forklaring.
+              </p>
+              <p>
+                Når du føler dig tryg ved punkterne ovenfor, er du klar til at udforske næste trin i simulatoren.
+              </p>
+            </section>
+          </div>
+          <footer class="tutorial-panel__footer">
+            <p>
+              Spørgsmål er velkomne! Jo bedre vi forstår grundideen, desto nemmere bliver resten af forløbet.
+            </p>
+          </footer>
+        </div>
       </article>
     </div>
   `;

--- a/assets/app.js
+++ b/assets/app.js
@@ -24,7 +24,11 @@ const steps = [
   },
   {
     title: 'Prøv selv: Tilpas subnetting',
-    description: 'Eksperimenter med antal subnets eller hosts og se beregningerne opdatere med det samme.'
+    description: 'Eksperimenter med netværksklasser, antal subnets eller hosts og se beregningerne opdatere med det samme.'
+  },
+  {
+    title: 'Øvelser: 30 subnetting-opgaver',
+    description: 'Test din viden med opgaver, få feedback fra AI og følg din fremgang.'
   }
 ];
 
@@ -43,11 +47,34 @@ const subnet2Devices = Array.from({ length: 12 }, (_, i) => ({
   ip: `192.168.1.${129 + i}`
 }));
 
+const networkClasses = {
+  A: {
+    label: 'Klasse A',
+    baseIp: '10.0.0.0',
+    prefix: 8
+  },
+  B: {
+    label: 'Klasse B',
+    baseIp: '172.16.0.0',
+    prefix: 16
+  },
+  C: {
+    label: 'Klasse C',
+    baseIp: '192.168.1.0',
+    prefix: 24
+  }
+};
+
 const state = {
   step: 0,
   calculationMode: 'subnets',
   customSubnets: 2,
-  customHosts: 126
+  customHosts: 126,
+  networkClass: 'C',
+  tasks: null,
+  tasksLoading: false,
+  tasksError: null,
+  taskStatuses: {}
 };
 
 let broadcastGenerator = null;
@@ -59,6 +86,7 @@ let subnetAnimators = [];
 let routerTrafficGenerators = [];
 let routerTrafficAnimators = [];
 let routerTrafficCleanups = [];
+let tasksPromise = null;
 
 function getDevicePosition(index) {
   const row = Math.floor(index / 6);
@@ -78,50 +106,139 @@ function getSubnetDevicePosition(index) {
   };
 }
 
+function ipToNumber(ipString) {
+  const parts = ipString.split('.').map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => Number.isNaN(part))) {
+    return 0;
+  }
+
+  return (
+    (parts[0] << 24)
+    | (parts[1] << 16)
+    | (parts[2] << 8)
+    | parts[3]
+  ) >>> 0;
+}
+
+function numberToIp(num) {
+  const a = (num >>> 24) & 255;
+  const b = (num >>> 16) & 255;
+  const c = (num >>> 8) & 255;
+  const d = num & 255;
+  return `${a}.${b}.${c}.${d}`;
+}
+
+function prefixToMask(prefix) {
+  const mask = [];
+  let remaining = prefix;
+  for (let i = 0; i < 4; i += 1) {
+    const bits = Math.max(Math.min(remaining, 8), 0);
+    const value = bits === 0 ? 0 : 256 - 2 ** (8 - bits);
+    mask.push(value);
+    remaining -= bits;
+  }
+  return mask.join('.');
+}
+
+function loadSubnetTasks() {
+  if (tasksPromise) {
+    return tasksPromise;
+  }
+
+  tasksPromise = fetch('data/subnet_tasks.json', { cache: 'no-cache' })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Kunne ikke hente opgaverne.');
+      }
+      return response.json();
+    })
+    .then((data) => {
+      if (!Array.isArray(data)) {
+        throw new Error('Uventet format for opgaver.');
+      }
+      return data;
+    })
+    .catch((error) => {
+      tasksPromise = null;
+      throw error;
+    });
+
+  return tasksPromise;
+}
+
+function escapeHtml(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function calculateSubnetting() {
+  const classData = networkClasses[state.networkClass] || networkClasses.C;
+  const basePrefix = classData.prefix;
+  const baseIp = classData.baseIp;
+  const totalHostBits = 32 - basePrefix;
+
   let subnetBits;
   let numSubnets;
   let hostsPerSubnet;
+  let effectiveHostBits;
+  let capacityWarning = '';
 
   if (state.calculationMode === 'subnets') {
-    numSubnets = state.customSubnets;
-    subnetBits = Math.ceil(Math.log2(numSubnets));
-    hostsPerSubnet = Math.pow(2, 8 - subnetBits) - 2;
-  } else {
-    hostsPerSubnet = state.customHosts;
-    const hostBits = Math.ceil(Math.log2(hostsPerSubnet + 2));
-    subnetBits = 8 - hostBits;
-    if (subnetBits < 0) {
-      subnetBits = 0;
+    const requestedSubnets = Math.max(1, state.customSubnets);
+    const requestedBits = Math.ceil(Math.log2(requestedSubnets));
+    subnetBits = Math.min(requestedBits, totalHostBits);
+    numSubnets = 2 ** subnetBits;
+    effectiveHostBits = Math.max(totalHostBits - subnetBits, 0);
+    hostsPerSubnet = effectiveHostBits > 0 ? 2 ** effectiveHostBits - 2 : 0;
+    if (requestedBits > totalHostBits) {
+      capacityWarning = 'Der er ikke nok bits til så mange subnets i denne klasse. Viser maks mulige subnets.';
     }
-    numSubnets = Math.pow(2, Math.max(subnetBits, 0));
+  } else {
+    const requestedHosts = Math.max(0, state.customHosts);
+    const requestedHostBits = Math.ceil(Math.log2(requestedHosts + 2));
+    effectiveHostBits = Math.min(requestedHostBits, totalHostBits);
+    subnetBits = Math.max(totalHostBits - effectiveHostBits, 0);
+    numSubnets = 2 ** subnetBits;
+    hostsPerSubnet = effectiveHostBits > 0 ? 2 ** effectiveHostBits - 2 : 0;
+    if (requestedHostBits > totalHostBits) {
+      capacityWarning = 'Der er ikke nok værts-bits i denne klasse til det ønskede antal hosts. Viser maks mulige hosts.';
+    }
   }
 
-  if (subnetBits < 0) {
-    subnetBits = 0;
-  }
+  subnetBits = Math.max(subnetBits, 0);
 
-  const newPrefix = 24 + subnetBits;
-  const subnetMaskLastOctet = 256 - Math.pow(2, 8 - subnetBits);
-  const blockSize = Math.pow(2, 8 - subnetBits);
+  const newPrefix = Math.min(basePrefix + subnetBits, 32);
+  const blockSize = 2 ** Math.max(32 - newPrefix, 0);
+  const subnetMask = prefixToMask(newPrefix);
 
   const subnets = [];
+  const baseNumber = ipToNumber(baseIp);
+  const totalRange = 2 ** Math.max(totalHostBits, 0);
+  const maxRangeEnd = baseNumber + totalRange - 1;
+
   for (let i = 0; i < numSubnets && i < 256; i += 1) {
-    const networkAddress = i * blockSize;
-    if (networkAddress > 255) {
+    const networkNumber = baseNumber + i * blockSize;
+    if (networkNumber > maxRangeEnd) {
       break;
     }
 
-    const firstHost = networkAddress + 1;
-    const lastHost = networkAddress + blockSize - 2;
-    const broadcast = networkAddress + blockSize - 1;
+    const broadcastNumber = Math.min(networkNumber + blockSize - 1, maxRangeEnd);
+    const firstHostNumber = blockSize > 2 ? networkNumber + 1 : (blockSize > 1 ? networkNumber + 1 : networkNumber);
+    const lastHostNumber = blockSize > 2 ? broadcastNumber - 1 : (blockSize > 1 ? broadcastNumber - 1 : networkNumber);
 
     subnets.push({
       id: i,
-      network: `192.168.1.${networkAddress}`,
-      firstHost: `192.168.1.${firstHost}`,
-      lastHost: `192.168.1.${lastHost}`,
-      broadcast: `192.168.1.${broadcast}`,
+      network: numberToIp(networkNumber),
+      firstHost: hostsPerSubnet > 0 ? numberToIp(firstHostNumber) : 'Ingen brugbare hosts',
+      lastHost: hostsPerSubnet > 0 ? numberToIp(lastHostNumber) : 'Ingen brugbare hosts',
+      broadcast: numberToIp(broadcastNumber),
       usableHosts: hostsPerSubnet,
       prefix: newPrefix
     });
@@ -133,8 +250,15 @@ function calculateSubnetting() {
     numSubnets,
     hostsPerSubnet,
     newPrefix,
-    subnetMask: `255.255.255.${subnetMaskLastOctet}`,
-    blockSize
+    subnetMask,
+    blockSize,
+    baseIp,
+    basePrefix,
+    classLabel: classData.label,
+    totalHostBits,
+    sliderMaxPower: Math.max(Math.min(totalHostBits, 10), 0),
+    hostsSliderMax: Math.max(2, Math.min(65534, 2 ** Math.min(totalHostBits, 16) - 2)),
+    capacityWarning
   };
 }
 
@@ -352,6 +476,9 @@ function renderStep1() {
           <div class="absolute left-0 right-0 bottom-6 text-center z-30">
             <span class="inline-flex items-center gap-1 ${subnet.badgeClasses} px-3 py-1 rounded-full text-xs font-semibold">📶 Lokalt broadcast</span>
           </div>
+          <div class="router-gate-note ${subnet.id === 1 ? 'left' : 'right'}">
+            <span>Routeren afviser broadcast til det andet subnet</span>
+          </div>
         </div>
       `;
     })
@@ -375,10 +502,25 @@ function renderStep1() {
         <path id="router-path-right" d="M50 26 C56 32 62 36 66 42" stroke="#38bdf8" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.75" fill="none"></path>
         <circle cx="34" cy="42" r="1.5" fill="#0f766e" fill-opacity="0.8"></circle>
         <circle cx="66" cy="42" r="1.5" fill="#0369a1" fill-opacity="0.8"></circle>
+        <g class="router-stop-marker" transform="translate(34 42)">
+          <circle r="4.1"></circle>
+          <text x="0" y="1.5">🚫</text>
+        </g>
+        <g class="router-stop-marker" transform="translate(66 42)">
+          <circle r="4.1"></circle>
+          <text x="0" y="1.5">🚫</text>
+        </g>
       </svg>
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 pt-40">
         ${panels}
+      </div>
+
+      <div class="router-stop-banner left">
+        <span>🚫 Routeren stopper broadcast videre mod Subnet 2</span>
+      </div>
+      <div class="router-stop-banner right">
+        <span>🚫 Ingen broadcast sendes videre til Subnet 1</span>
       </div>
     </div>
   `;
@@ -504,6 +646,24 @@ function renderStep3() {
 
 function renderStep4() {
   const calc = calculateSubnetting();
+  const subnetModeActive = state.calculationMode === 'subnets';
+  const desiredPower = Math.round(Math.log2(Math.max(state.customSubnets, 1)));
+  const sliderPower = Math.min(desiredPower, calc.sliderMaxPower);
+  if (subnetModeActive && desiredPower !== sliderPower) {
+    state.customSubnets = 2 ** sliderPower;
+  }
+
+  if (!subnetModeActive) {
+    const clampedHosts = Math.min(Math.max(state.customHosts, 2), calc.hostsSliderMax);
+    if (clampedHosts !== state.customHosts) {
+      state.customHosts = clampedHosts;
+    }
+  }
+
+  const hostBitsLeft = Math.max(calc.totalHostBits - calc.subnetBits, 0);
+  const hostExplanation = hostBitsLeft > 0
+    ? `• Det giver 2<sup>${hostBitsLeft}</sup> - 2 = <strong>${calc.hostsPerSubnet} brugbare hosts</strong> pr. subnet`
+    : '• Ingen værtsbits tilbage - kun netværks- og broadcast-adresser uden brugbare værter.';
 
   const subnetCards = calc.subnets
     .map(
@@ -527,9 +687,12 @@ function renderStep4() {
               <p class="text-xs text-gray-600 font-semibold uppercase">Broadcast</p>
               <p class="font-mono text-gray-800 font-bold">${subnet.broadcast}</p>
             </div>
-            <div class="bg-purple-50 rounded p-2 text-center border border-purple-200">
-              <p class="text-xs text-gray-600 uppercase">Brugbare hosts</p>
+            <div class="bg-purple-100 rounded p-2 text-center border border-purple-300">
+              <p class="text-xs text-gray-600 font-semibold uppercase">Brugbare hosts</p>
               <p class="text-xl font-bold text-purple-600">${subnet.usableHosts}</p>
+            </div>
+            <div class="bg-yellow-50 rounded p-2 text-xs text-slate-600">
+              <p><strong>Subnet mask:</strong> ${calc.subnetMask}</p>
             </div>
           </div>
         </div>
@@ -538,75 +701,110 @@ function renderStep4() {
     .join('');
 
   visualizationEl.innerHTML = `
-    <div class="space-y-5">
-      <div class="bg-purple-50 border-2 border-purple-400 rounded-xl p-4">
-        <h3 class="text-lg font-bold text-gray-800 mb-3">🎮 Eksperimenter med subnetting</h3>
-        <div class="flex flex-col md:flex-row gap-3">
-          <button data-mode="subnets" class="flex-1 py-2 px-3 rounded-lg font-bold text-sm border ${state.calculationMode === 'subnets' ? 'bg-purple-600 text-white border-purple-600' : 'bg-white text-gray-700 border-gray-300'}">Vælg antal subnets</button>
-          <button data-mode="hosts" class="flex-1 py-2 px-3 rounded-lg font-bold text-sm border ${state.calculationMode === 'hosts' ? 'bg-purple-600 text-white border-purple-600' : 'bg-white text-gray-700 border-gray-300'}">Vælg antal hosts pr. subnet</button>
+    <div class="space-y-4">
+      <div class="bg-white border border-slate-200 rounded-xl p-4 flex flex-wrap items-center gap-3 justify-between">
+        <div>
+          <p class="text-sm font-semibold text-slate-600">Vælg netværksklasse:</p>
+          <div class="flex flex-wrap gap-2 mt-2">
+            ${Object.entries(networkClasses)
+              .map(([key, classInfo]) => {
+                const isActive = state.networkClass === key;
+                return `
+                  <button type="button" class="network-class-btn ${isActive ? 'active' : ''}" data-network-class="${key}">
+                    ${classInfo.label}
+                    <span>${classInfo.baseIp}/${classInfo.prefix}</span>
+                  </button>
+                `;
+              })
+              .join('')}
+          </div>
         </div>
-        <div class="bg-white border border-purple-200 rounded-lg p-4 mt-3">
-          ${state.calculationMode === 'subnets'
-            ? `
-              <label class="block text-sm font-semibold text-gray-800 mb-2">Hvor mange subnets vil du have?</label>
-              <div class="flex items-center gap-4">
-                <input type="range" id="subnet-range" min="0" max="8" step="1" value="${Math.log2(state.customSubnets)}" class="flex-1" />
-                <span class="text-3xl font-bold text-purple-600 min-w-[3rem] text-center">${state.customSubnets}</span>
-              </div>
-              <p class="text-xs text-gray-500 mt-1">Værdien er en potens af to (2, 4, 8, ... 256).</p>
-            `
-            : `
-              <label class="block text-sm font-semibold text-gray-800 mb-2">Hvor mange hosts skal der være plads til pr. subnet?</label>
-              <div class="flex items-center gap-4">
-                <input type="range" id="hosts-range" min="2" max="254" value="${state.customHosts}" class="flex-1" />
-                <span class="text-3xl font-bold text-purple-600 min-w-[3rem] text-center">${state.customHosts}</span>
-              </div>
-            `}
+        <div class="text-sm text-slate-600 leading-5">
+          <p><strong>Aktiv klasse:</strong> ${calc.classLabel}</p>
+          <p><strong>Base:</strong> ${calc.baseIp}/${calc.basePrefix}</p>
+          <p><strong>Tilgængelige værtsbits:</strong> ${calc.totalHostBits}</p>
         </div>
       </div>
 
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <div class="bg-white border-2 border-indigo-400 rounded-xl p-3 text-center">
-          <p class="text-xs text-gray-500 uppercase">Antal subnets</p>
-          <p class="text-2xl font-bold text-indigo-600">${calc.numSubnets}</p>
+      <div class="bg-purple-50 border-2 border-purple-400 rounded-lg p-3">
+        <h3 class="text-base md:text-lg font-bold text-gray-800 mb-3">🎮 Eksperimenter med subnetting:</h3>
+        <div class="flex gap-2 md:gap-3 mb-3">
+          <button data-mode="subnets" class="flex-1 py-2 px-3 rounded-lg font-bold text-xs md:text-sm transition-colors ${subnetModeActive ? 'bg-purple-600 text-white' : 'bg-white text-gray-700 border-2 border-gray-300 hover:border-purple-300'}">Vælg antal subnets</button>
+          <button data-mode="hosts" class="flex-1 py-2 px-3 rounded-lg font-bold text-xs md:text-sm transition-colors ${!subnetModeActive ? 'bg-purple-600 text-white' : 'bg-white text-gray-700 border-2 border-gray-300 hover:border-purple-300'}">Vælg antal hosts pr. subnet</button>
         </div>
-        <div class="bg-white border-2 border-indigo-400 rounded-xl p-3 text-center">
-          <p class="text-xs text-gray-500 uppercase">Hosts pr. subnet</p>
-          <p class="text-2xl font-bold text-indigo-600">${calc.hostsPerSubnet}</p>
+        <div class="bg-white p-3 rounded-lg border-2 border-purple-300">
+          ${subnetModeActive
+            ? `
+                <label class="block text-gray-800 font-bold mb-2 text-sm">Hvor mange subnets vil du have?</label>
+                <div class="flex items-center gap-3">
+                  <input type="range" min="0" max="${calc.sliderMaxPower}" value="${sliderPower}" id="subnet-range" class="flex-1" />
+                  <span class="text-xl md:text-2xl font-bold text-purple-600 w-16 text-center">${state.customSubnets}</span>
+                </div>
+                <p class="text-xs text-gray-600 mt-1">Potenser af 2 op til klassens kapacitet.</p>
+              `
+            : `
+                <label class="block text-gray-800 font-bold mb-2 text-sm">Hvor mange hosts skal der være plads til pr. subnet?</label>
+                <div class="flex items-center gap-3">
+                  <input type="range" min="2" max="${calc.hostsSliderMax}" value="${state.customHosts}" id="hosts-range" class="flex-1" />
+                  <span class="text-xl md:text-2xl font-bold text-purple-600 w-16 text-center">${state.customHosts}</span>
+                </div>
+              `}
         </div>
-        <div class="bg-white border-2 border-indigo-400 rounded-xl p-3 text-center">
-          <p class="text-xs text-gray-500 uppercase">Subnet bits lånt</p>
-          <p class="text-2xl font-bold text-indigo-600">${calc.subnetBits}</p>
+      </div>
+
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
+        <div class="bg-white p-2 md:p-3 rounded-lg border-2 border-indigo-400 text-center">
+          <p class="text-xs text-gray-600 mb-0.5">Antal subnets</p>
+          <p class="text-2xl md:text-3xl font-bold text-indigo-600">${calc.numSubnets}</p>
         </div>
-        <div class="bg-white border-2 border-indigo-400 rounded-xl p-3 text-center">
-          <p class="text-xs text-gray-500 uppercase">Ny subnet mask</p>
-          <p class="text-lg font-bold text-indigo-600">${calc.subnetMask}</p>
+        <div class="bg-white p-2 md:p-3 rounded-lg border-2 border-indigo-400 text-center">
+          <p class="text-xs text-gray-600 mb-0.5">Hosts pr. subnet</p>
+          <p class="text-2xl md:text-3xl font-bold text-indigo-600">${calc.hostsPerSubnet}</p>
+        </div>
+        <div class="bg-white p-2 md:p-3 rounded-lg border-2 border-indigo-400 text-center">
+          <p class="text-xs text-gray-600 mb-0.5">Subnet bits lånt</p>
+          <p class="text-2xl md:text-3xl font-bold text-indigo-600">${calc.subnetBits}</p>
+        </div>
+        <div class="bg-white p-2 md:p-3 rounded-lg border-2 border-indigo-400 text-center">
+          <p class="text-xs text-gray-600 mb-0.5">Ny subnet mask</p>
+          <p class="text-base md:text-xl font-bold text-indigo-600">${calc.subnetMask}</p>
           <p class="text-xs text-gray-500">/${calc.newPrefix}</p>
         </div>
       </div>
 
-      <div class="bg-yellow-50 border-2 border-yellow-400 rounded-xl p-4 text-sm text-gray-700">
-        <p class="font-bold text-gray-800 mb-2">💡 Hvorfor disse tal?</p>
-        <ul class="list-disc list-inside space-y-1">
-          <li>Vi startede med /24 (8 bits til hosts).</li>
-          <li>Vi låner <strong>${calc.subnetBits}</strong> bit(s) til subnetting.</li>
-          <li>Det giver 2<sup>${calc.subnetBits}</sup> = <strong>${calc.numSubnets}</strong> subnets.</li>
-          <li>Der er ${8 - calc.subnetBits} bits tilbage til hosts.</li>
-          <li>Brugbare hosts: 2<sup>${8 - calc.subnetBits}</sup> − 2 = <strong>${calc.hostsPerSubnet}</strong>.</li>
-        </ul>
+      <div class="bg-yellow-50 border-2 border-yellow-400 rounded-lg p-3">
+        <p class="font-bold text-gray-800 mb-1 text-sm">💡 Hvorfor disse tal?</p>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-1 text-xs text-gray-700">
+          <p>• Vi startede med /${calc.basePrefix} (${calc.totalHostBits} bits til hosts)</p>
+          <p>• Vi låner <strong>${calc.subnetBits} bit(s)</strong> til subnetting</p>
+          <p>• Dette giver os 2<sup>${calc.subnetBits}</sup> = <strong>${calc.numSubnets} subnets</strong></p>
+          <p>• Der er nu ${hostBitsLeft} bits tilbage til hosts</p>
+          <p class="md:col-span-2">${hostExplanation}</p>
+        </div>
+        ${calc.capacityWarning ? `<p class="text-xs text-amber-600 font-semibold mt-2">⚠️ ${calc.capacityWarning}</p>` : ''}
       </div>
 
-      <div class="bg-gradient-to-br from-slate-100 to-slate-200 border-4 border-slate-300 rounded-xl p-4">
+      <div class="bg-gradient-to-br from-gray-100 to-gray-200 border-4 border-gray-400 rounded-lg p-4">
         <div class="flex items-center justify-between mb-3">
-          <h4 class="text-lg font-bold text-gray-800">🌐 Netværk: 192.168.1.0/${calc.newPrefix}</h4>
-          <span class="bg-white border border-gray-300 rounded-lg px-3 py-1 text-sm font-semibold text-gray-700">${calc.numSubnets} subnets</span>
+          <h3 class="text-lg md:text-xl font-bold text-gray-800">
+            🌐 Netværk: ${calc.baseIp}/${calc.newPrefix}
+          </h3>
+          <div class="bg-white px-3 py-1 rounded-lg border-2 border-gray-400">
+            <span class="font-bold text-sm text-gray-800">${calc.numSubnets} Subnets</span>
+          </div>
         </div>
         <div class="card-grid grid-scroll">
           ${subnetCards}
         </div>
-        ${calc.subnets.length >= 256
-          ? '<p class="text-xs text-gray-500 mt-2">Viser de første 256 subnets for at holde listen håndterbar.</p>'
-          : ''}
+        ${calc.subnets.length >= 256 ? '<p class="text-xs text-gray-500 mt-2">Viser de første 256 subnets for at holde listen håndterbar.</p>' : ''}
+      </div>
+
+      <div class="bg-green-100 border-2 border-green-500 rounded-lg p-3">
+        <p class="text-xs md:text-sm text-gray-700">
+          <strong>💡 Vigtigt at huske:</strong> Bemærk hvordan flere subnets betyder færre hosts pr. subnet,
+          og omvendt. Dette er en fundamental del af subnetting - du skal balancere mellem
+          antal netværk og antal enheder pr. netværk baseret på dine behov!
+        </p>
       </div>
     </div>
   `;
@@ -614,11 +812,41 @@ function renderStep4() {
   visualizationEl.querySelectorAll('[data-mode]').forEach((button) => {
     button.addEventListener('click', () => {
       const mode = button.getAttribute('data-mode');
+      if (!mode) {
+        return;
+      }
       state.calculationMode = mode;
       if (mode === 'subnets' && (state.customSubnets & (state.customSubnets - 1)) !== 0) {
-        // Sikrer at værdien er en potens af to
         state.customSubnets = 2;
       }
+      renderStep4();
+    });
+  });
+
+  visualizationEl.querySelectorAll('[data-network-class]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const selected = button.getAttribute('data-network-class');
+      if (!selected || !networkClasses[selected]) {
+        return;
+      }
+      if (selected === state.networkClass) {
+        return;
+      }
+
+      state.networkClass = selected;
+
+      const classInfo = networkClasses[selected];
+      const hostBits = 32 - classInfo.prefix;
+      const maxPower = Math.max(Math.min(hostBits, 10), 0);
+      const currentPower = Math.round(Math.log2(Math.max(state.customSubnets, 1)));
+      if (currentPower > maxPower) {
+        state.customSubnets = 2 ** maxPower || 1;
+      }
+      const maxHosts = Math.max(2, Math.min(65534, 2 ** Math.min(hostBits, 16) - 2));
+      if (state.customHosts > maxHosts) {
+        state.customHosts = maxHosts;
+      }
+
       renderStep4();
     });
   });
@@ -627,7 +855,7 @@ function renderStep4() {
   if (subnetRange) {
     subnetRange.addEventListener('input', (event) => {
       const power = Number(event.target.value);
-      state.customSubnets = Math.pow(2, power);
+      state.customSubnets = 2 ** power;
       renderStep4();
     });
   }
@@ -639,6 +867,217 @@ function renderStep4() {
       renderStep4();
     });
   }
+}
+
+function setTaskStatus(taskId, status, details = {}) {
+  const current = state.taskStatuses[taskId] || {};
+  state.taskStatuses[taskId] = {
+    ...current,
+    ...details,
+    status
+  };
+}
+
+function submitTaskAnswer(taskId) {
+  if (!state.tasks) {
+    return;
+  }
+
+  const input = visualizationEl.querySelector(`[data-task-input="${taskId}"]`);
+  if (!input) {
+    return;
+  }
+
+  const answer = input.value.trim();
+
+  if (answer === '') {
+    setTaskStatus(taskId, 'incomplete', {
+      feedback: 'Skriv dit svar, før du sender det til evaluering.',
+      answer: ''
+    });
+    renderStep5();
+    return;
+  }
+
+  setTaskStatus(taskId, 'checking', {
+    feedback: 'Tjekker svar hos AI...',
+    answer
+  });
+  renderStep5();
+
+  fetch('api/check-subnet-task.php', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      taskId,
+      answer
+    })
+  })
+    .then((response) => response.json().catch(() => ({ error: 'Uventet svar fra serveren.' })))
+    .then((data) => {
+      if (!data || data.error) {
+        setTaskStatus(taskId, 'error', {
+          feedback: data && data.error ? data.error : 'Ukendt fejl under evalueringen.',
+          answer
+        });
+      } else {
+        const normalizedStatus = data.status === 'correct' ? 'correct' : data.status === 'incorrect' ? 'incorrect' : 'error';
+        setTaskStatus(taskId, normalizedStatus, {
+          feedback: data.feedback || '',
+          answer
+        });
+      }
+      renderStep5();
+    })
+    .catch((error) => {
+      setTaskStatus(taskId, 'error', {
+        feedback: error instanceof Error ? error.message : 'Der opstod en ukendt fejl.',
+        answer
+      });
+      renderStep5();
+    });
+}
+
+function getTaskStatusLabel(status) {
+  switch (status) {
+    case 'correct':
+      return '✅ Korrekt besvarelse';
+    case 'incorrect':
+      return '❌ Ikke korrekt endnu';
+    case 'checking':
+      return '⏳ Evaluerer...';
+    case 'error':
+      return '⚠️ Fejl under evaluering';
+    case 'incomplete':
+      return '✍️ Svar mangler';
+    default:
+      return '📄 Klar til besvarelse';
+  }
+}
+
+function renderStep5() {
+  if (state.tasksError) {
+    visualizationEl.innerHTML = `
+      <div class="min-h-[400px] flex flex-col items-center justify-center text-center gap-3">
+        <div class="text-4xl">😕</div>
+        <p class="text-sm md:text-base text-gray-700 max-w-lg">${escapeHtml(state.tasksError)}</p>
+        <button type="button" class="btn-primary" id="retry-load-tasks">Prøv at indlæse opgaverne igen</button>
+      </div>
+    `;
+
+    const retryButton = document.getElementById('retry-load-tasks');
+    if (retryButton) {
+      retryButton.addEventListener('click', () => {
+        state.tasksError = null;
+        state.tasks = null;
+        renderStep5();
+      });
+    }
+    return;
+  }
+
+  if (!state.tasks) {
+    visualizationEl.innerHTML = `
+      <div class="min-h-[400px] flex flex-col items-center justify-center text-center gap-2">
+        <div class="loading-spinner"></div>
+        <p class="text-sm text-gray-600">Indlæser 30 opgaver i subnetting...</p>
+      </div>
+    `;
+
+    if (!state.tasksLoading) {
+      state.tasksLoading = true;
+      loadSubnetTasks()
+        .then((tasks) => {
+          state.tasks = tasks;
+          state.tasksLoading = false;
+          renderStep5();
+        })
+        .catch((error) => {
+          state.tasksLoading = false;
+          state.tasksError = error instanceof Error ? error.message : 'Kunne ikke hente opgaverne.';
+          renderStep5();
+        });
+    }
+    return;
+  }
+
+  const totalTasks = state.tasks.length;
+  const solvedCount = state.tasks.reduce((count, task) => {
+    const status = state.taskStatuses[task.id]?.status;
+    return status === 'correct' ? count + 1 : count;
+  }, 0);
+  const percent = totalTasks > 0 ? Math.round((solvedCount / totalTasks) * 100) : 0;
+
+  const cards = state.tasks
+    .map((task, index) => {
+      const statusInfo = state.taskStatuses[task.id] || {};
+      const statusClass = statusInfo.status ? ` ${statusInfo.status}` : '';
+      const label = getTaskStatusLabel(statusInfo.status);
+      const storedAnswer = statusInfo.answer || '';
+      const feedback = statusInfo.feedback ? `<div class="task-feedback ${statusInfo.status || 'idle'}">${escapeHtml(statusInfo.feedback)}</div>` : '';
+      const promptHtml = escapeHtml(task.prompt || '').replace(/\n/g, '<br>');
+      const category = task.category ? `<span class="task-tag">${escapeHtml(task.category)}</span>` : '';
+      const disabledAttr = statusInfo.status === 'checking' ? 'disabled' : '';
+      const buttonLabel = statusInfo.status === 'checking' ? 'Evaluerer...' : 'Send svar';
+
+      return `
+        <article class="task-card${statusClass}" data-task-id="${task.id}">
+          <header class="task-card-header">
+            <div>
+              <p class="task-title">Opgave ${index + 1}</p>
+              ${category}
+            </div>
+            <p class="task-status">${label}</p>
+          </header>
+          <div class="task-body">
+            <p class="task-prompt">${promptHtml}</p>
+            <textarea data-task-input="${task.id}" rows="3" class="task-answer" placeholder="Skriv dit svar her..." ${disabledAttr}>${escapeHtml(storedAnswer)}</textarea>
+          </div>
+          <footer class="task-footer">
+            <button type="button" class="btn-primary task-submit" data-task-submit="${task.id}" ${disabledAttr}>${buttonLabel}</button>
+            ${feedback}
+          </footer>
+        </article>
+      `;
+    })
+    .join('');
+
+  visualizationEl.innerHTML = `
+    <div class="space-y-4">
+      <div class="bg-white border border-slate-200 rounded-xl p-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 class="text-lg font-bold text-slate-800">🧠 Subnetting-øvelser</h3>
+          <p class="text-sm text-slate-600">Skriv dine svar og få feedback fra AI for hver opgave.</p>
+        </div>
+        <div class="task-progress">
+          <span class="task-progress-count">${solvedCount}/${totalTasks} løst</span>
+          <div class="task-progress-bar">
+            <div style="width: ${percent}%"></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-indigo-50 border border-indigo-200 rounded-lg p-4 text-sm text-slate-700">
+        <p>Tip: Skriv dine beregninger tydeligt. Hvis svaret ikke stemmer, får du feedback om, hvad du bør dobbelttjekke.</p>
+      </div>
+
+      <div class="task-grid">
+        ${cards}
+      </div>
+    </div>
+  `;
+
+  visualizationEl.querySelectorAll('[data-task-submit]').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      const id = Number(event.currentTarget.getAttribute('data-task-submit'));
+      if (Number.isNaN(id)) {
+        return;
+      }
+      submitTaskAnswer(id);
+    });
+  });
 }
 
 function renderVisualization() {
@@ -663,6 +1102,9 @@ function renderVisualization() {
       break;
     case 4:
       renderStep4();
+      break;
+    case 5:
+      renderStep5();
       break;
     default:
       visualizationEl.innerHTML = '';
@@ -698,7 +1140,7 @@ function setupRouterTraffic({ pathId, color, burstColor }) {
       progress: 0
     });
 
-    if (activePackets.length > 6) {
+    if (activePackets.length > 10) {
       const stale = activePackets.shift();
       if (stale && stale.element && stale.element.parentNode) {
         stale.element.parentNode.removeChild(stale.element);
@@ -707,10 +1149,10 @@ function setupRouterTraffic({ pathId, color, burstColor }) {
   };
 
   const generator = setInterval(() => {
-    if (Math.random() < 0.6) {
+    if (Math.random() < 0.85) {
       spawnPacket();
     }
-  }, 900);
+  }, 600);
 
   const animator = setInterval(() => {
     for (let i = activePackets.length - 1; i >= 0; i -= 1) {
@@ -926,12 +1368,13 @@ function setupBroadcastScene() {
     line.setAttribute('x2', '50');
     line.setAttribute('y2', '12');
     line.setAttribute('stroke', '#9ca3af');
-    line.setAttribute('stroke-width', '1.8');
+    line.setAttribute('stroke-width', '5');
     line.setAttribute('stroke-linecap', 'round');
+    line.setAttribute('vector-effect', 'non-scaling-stroke');
     lineLayer.appendChild(line);
   });
 
-  broadcastGenerator = setInterval(() => {
+  const spawnPacket = () => {
     const fromIndex = Math.floor(Math.random() * originalDevices.length);
     const startPos = getDevicePosition(fromIndex);
 
@@ -951,24 +1394,31 @@ function setupBroadcastScene() {
       targetPos
     };
 
-    packet.element.setAttribute('r', '2.2');
+    packet.element.setAttribute('r', '2.6');
     packet.element.setAttribute('class', 'packet');
     packet.element.setAttribute('cx', startPos.x);
     packet.element.setAttribute('cy', startPos.y);
     packetLayer.appendChild(packet.element);
     broadcastPackets.push(packet);
 
-    if (broadcastPackets.length > 12) {
+    if (broadcastPackets.length > 20) {
       const removed = broadcastPackets.shift();
       if (removed && removed.element && removed.element.parentNode) {
         removed.element.parentNode.removeChild(removed.element);
       }
     }
-  }, 450);
+  };
+
+  broadcastGenerator = setInterval(() => {
+    spawnPacket();
+    if (Math.random() < 0.45) {
+      spawnPacket();
+    }
+  }, 220);
 
   broadcastAnimator = setInterval(() => {
     broadcastPackets = broadcastPackets.filter((packet) => {
-      const nextProgress = packet.progress + 0.05;
+      const nextProgress = packet.progress + 0.065;
       packet.progress = nextProgress;
 
       if (nextProgress > 2) {
@@ -1021,6 +1471,8 @@ nextBtn.addEventListener('click', () => {
     state.calculationMode = 'subnets';
     state.customSubnets = 2;
     state.customHosts = 126;
+    state.networkClass = 'C';
+    state.taskStatuses = {};
     updateUI();
     return;
   }

--- a/assets/app.js
+++ b/assets/app.js
@@ -27,7 +27,7 @@ const steps = [
     description: 'Eksperimenter med netværksklasser, antal subnets eller hosts og se beregningerne opdatere med det samme.'
   },
   {
-    title: 'Øvelser: 30 subnetting-opgaver',
+    title: 'Øvelser: 50 subnetting-opgaver',
     description: 'Test din viden med opgaver, få feedback fra AI og følg din fremgang.'
   }
 ];
@@ -498,16 +498,6 @@ function renderStep1() {
       <svg class="absolute inset-0 w-full h-full pointer-events-none router-link-layer" viewBox="0 0 100 100" preserveAspectRatio="none">
         <path id="router-path-left" d="M50 24 C44 31 38 36 33 43" stroke="#14b8a6" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.78" fill="none"></path>
         <path id="router-path-right" d="M50 24 C56 31 62 36 67 43" stroke="#38bdf8" stroke-width="3.2" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.78" fill="none"></path>
-        <circle cx="33" cy="43" r="1.4" fill="#0f766e" fill-opacity="0.85"></circle>
-        <circle cx="67" cy="43" r="1.4" fill="#0369a1" fill-opacity="0.85"></circle>
-        <g class="router-stop-marker" transform="translate(33 43)">
-          <circle class="router-stop-marker__outer" r="4.1"></circle>
-          <circle class="router-stop-marker__inner" r="1.35"></circle>
-        </g>
-        <g class="router-stop-marker" transform="translate(67 43)">
-          <circle class="router-stop-marker__outer" r="4.1"></circle>
-          <circle class="router-stop-marker__inner" r="1.35"></circle>
-        </g>
       </svg>
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 pt-40">
@@ -933,6 +923,25 @@ function submitTaskAnswer(taskId) {
     });
 }
 
+function revealTaskSolution(taskId) {
+  if (!state.tasks) {
+    return;
+  }
+
+  const task = state.tasks.find((item) => item.id === taskId);
+  if (!task) {
+    return;
+  }
+
+  const current = state.taskStatuses[taskId] || {};
+  state.taskStatuses[taskId] = {
+    ...current,
+    revealed: true
+  };
+
+  renderStep5();
+}
+
 function getTaskStatusLabel(status) {
   switch (status) {
     case 'correct':
@@ -975,7 +984,7 @@ function renderStep5() {
     visualizationEl.innerHTML = `
       <div class="min-h-[400px] flex flex-col items-center justify-center text-center gap-2">
         <div class="loading-spinner"></div>
-        <p class="text-sm text-gray-600">Indlæser 30 opgaver i subnetting...</p>
+        <p class="text-sm text-gray-600">Indlæser 50 opgaver i subnetting...</p>
       </div>
     `;
 
@@ -1014,6 +1023,12 @@ function renderStep5() {
       const category = task.category ? `<span class="task-tag">${escapeHtml(task.category)}</span>` : '';
       const disabledAttr = statusInfo.status === 'checking' ? 'disabled' : '';
       const buttonLabel = statusInfo.status === 'checking' ? 'Evaluerer...' : 'Send svar';
+      const isRevealed = Boolean(statusInfo.revealed);
+      const revealDisabledAttr = isRevealed ? 'disabled' : '';
+      const revealLabel = isRevealed ? 'Forklaring vist' : 'Vis forklaring';
+      const explanationBlock = isRevealed
+        ? `<div class="task-explanation"><p class="task-explanation-answer"><strong>Korrekt svar:</strong> ${escapeHtml(task.expectedAnswer || '')}</p><p>${escapeHtml(task.explanation || '').replace(/\n/g, '<br>')}</p></div>`
+        : '';
 
       return `
         <article class="task-card${statusClass}" data-task-id="${task.id}">
@@ -1029,8 +1044,12 @@ function renderStep5() {
             <textarea data-task-input="${task.id}" rows="3" class="task-answer" placeholder="Skriv dit svar her..." ${disabledAttr}>${escapeHtml(storedAnswer)}</textarea>
           </div>
           <footer class="task-footer">
-            <button type="button" class="btn-primary task-submit" data-task-submit="${task.id}" ${disabledAttr}>${buttonLabel}</button>
+            <div class="task-actions">
+              <button type="button" class="btn-primary task-submit" data-task-submit="${task.id}" ${disabledAttr}>${buttonLabel}</button>
+              <button type="button" class="btn-secondary task-reveal" data-task-reveal="${task.id}" ${revealDisabledAttr}>${revealLabel}</button>
+            </div>
             ${feedback}
+            ${explanationBlock}
           </footer>
         </article>
       `;
@@ -1069,6 +1088,16 @@ function renderStep5() {
         return;
       }
       submitTaskAnswer(id);
+    });
+  });
+
+  visualizationEl.querySelectorAll('[data-task-reveal]').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      const id = Number(event.currentTarget.getAttribute('data-task-reveal'));
+      if (Number.isNaN(id)) {
+        return;
+      }
+      revealTaskSolution(id);
     });
   });
 }

--- a/assets/app.js
+++ b/assets/app.js
@@ -490,7 +490,7 @@ function renderStep1() {
         </div>
         <div class="router-bridge-badge">Forbinder subnettene</div>
         <div id="router-stop-indicator" class="router-stop-label">
-          <span class="router-stop-icon">🚫</span>
+          <span class="router-stop-dot" aria-hidden="true"></span>
           <span>Router stopper broadcast til andre LAN</span>
         </div>
       </div>
@@ -501,12 +501,12 @@ function renderStep1() {
         <circle cx="33" cy="43" r="1.4" fill="#0f766e" fill-opacity="0.85"></circle>
         <circle cx="67" cy="43" r="1.4" fill="#0369a1" fill-opacity="0.85"></circle>
         <g class="router-stop-marker" transform="translate(33 43)">
-          <circle r="4.1"></circle>
-          <text x="0" y="1.5">🚫</text>
+          <circle class="router-stop-marker__outer" r="4.1"></circle>
+          <circle class="router-stop-marker__inner" r="1.35"></circle>
         </g>
         <g class="router-stop-marker" transform="translate(67 43)">
-          <circle r="4.1"></circle>
-          <text x="0" y="1.5">🚫</text>
+          <circle class="router-stop-marker__outer" r="4.1"></circle>
+          <circle class="router-stop-marker__inner" r="1.35"></circle>
         </g>
       </svg>
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -45,8 +45,6 @@ const subnet2Devices = Array.from({ length: 12 }, (_, i) => ({
 
 const state = {
   step: 0,
-  subnet1Collapsed: false,
-  subnet2Collapsed: false,
   calculationMode: 'subnets',
   customSubnets: 2,
   customHosts: 126
@@ -56,6 +54,8 @@ let broadcastGenerator = null;
 let broadcastAnimator = null;
 let broadcastPackets = [];
 let chefTimer = null;
+let subnetGenerators = [];
+let subnetAnimators = [];
 
 function getDevicePosition(index) {
   const row = Math.floor(index / 6);
@@ -63,6 +63,15 @@ function getDevicePosition(index) {
   return {
     x: 8 + col * 14.5,
     y: 35 + row * 14
+  };
+}
+
+function getSubnetDevicePosition(index) {
+  const row = Math.floor(index / 3);
+  const col = index % 3;
+  return {
+    x: 18 + col * 32,
+    y: 56 + row * 12
   };
 }
 
@@ -143,6 +152,10 @@ function cleanupStep() {
   }
 
   broadcastPackets = [];
+  subnetGenerators.forEach((interval) => clearInterval(interval));
+  subnetAnimators.forEach((interval) => clearInterval(interval));
+  subnetGenerators = [];
+  subnetAnimators = [];
 }
 
 function setStep(newStep) {
@@ -260,72 +273,110 @@ function renderStep0() {
   setupBroadcastScene();
 }
 
-function renderSubnetColumn(index) {
-  const isFirst = index === 1;
-  const devices = isFirst ? subnet1Devices : subnet2Devices;
-  const collapsed = isFirst ? state.subnet1Collapsed : state.subnet2Collapsed;
-  const color = isFirst ? 'green' : 'blue';
-  const borderClass = isFirst ? 'border-green-500 bg-green-50' : 'border-blue-500 bg-blue-50';
-  const headerBorder = isFirst ? 'border-green-400' : 'border-blue-400';
-  const badgeColor = isFirst ? 'bg-green-200 text-green-700' : 'bg-blue-200 text-blue-700';
-  const wifiEmoji = '📶';
-  const networkTitle = isFirst ? 'Subnet 1: 192.168.1.0/25' : 'Subnet 2: 192.168.1.128/25';
-  const maskTitle = 'Mask: 255.255.255.128';
+function renderStep1() {
+  const subnets = [
+    {
+      id: 1,
+      title: 'Subnet 1: 192.168.1.0/25',
+      mask: 'Mask: 255.255.255.128',
+      hostsLabel: '× 12 enheder',
+      svgId: 'subnet1-svg',
+      panelClasses: 'border-green-400 from-green-50 to-green-100',
+      portColor: 'bg-green-400',
+      badgeClasses: 'bg-green-200 text-green-700',
+      devices: subnet1Devices,
+      deviceBorderClass: 'border-green-400',
+      lineColor: '#34d399',
+      packetColor: '#22c55e'
+    },
+    {
+      id: 2,
+      title: 'Subnet 2: 192.168.1.128/25',
+      mask: 'Mask: 255.255.255.128',
+      hostsLabel: '× 12 enheder',
+      svgId: 'subnet2-svg',
+      panelClasses: 'border-blue-400 from-blue-50 to-blue-100',
+      portColor: 'bg-blue-400',
+      badgeClasses: 'bg-blue-200 text-blue-700',
+      devices: subnet2Devices,
+      deviceBorderClass: 'border-blue-400',
+      lineColor: '#60a5fa',
+      packetColor: '#2563eb'
+    }
+  ];
 
-  return `
-    <div class="border-4 ${borderClass} rounded-xl p-4 relative">
-      <button data-action="toggle-subnet" data-target="${index}" class="w-full flex items-center justify-between bg-white ${headerBorder} border-2 rounded-lg px-3 py-2 text-left shadow-sm">
-        <div>
-          <p class="font-bold text-gray-800 text-sm">${networkTitle}</p>
-          <p class="text-xs text-gray-600">${maskTitle}</p>
-          <p class="text-xs text-gray-500">× 12 enheder</p>
-        </div>
-        <span class="text-2xl text-${color}-600">${collapsed ? '▼' : '▲'}</span>
-      </button>
+  const routerPorts = Array.from({ length: 8 })
+    .map(() => '<span class="block w-2 h-6 rounded bg-emerald-400"></span>')
+    .join('');
 
-      ${collapsed
-        ? ''
-        : `
-          <div class="mt-4">
-            <div class="bg-gray-800 text-white rounded-lg border-4 border-gray-900 shadow-xl px-4 py-2 mx-auto w-fit">
-              <p class="text-xs font-bold text-center mb-1">SWITCH ${index}</p>
-              <div class="flex gap-1 justify-center">
-                ${Array.from({ length: 6 })
-                  .map(() => '<span class="block w-2 h-5 bg-green-400 rounded"></span>')
-                  .join('')}
-              </div>
-            </div>
+  const panels = subnets
+    .map((subnet) => {
+      const deviceGrid = createDeviceCards(subnet.devices, subnet.deviceBorderClass);
+      const switchPorts = Array.from({ length: 6 })
+        .map(() => `<span class="block w-2 h-5 ${subnet.portColor} rounded"></span>`)
+        .join('');
 
-            <div class="grid grid-cols-3 gap-2 mt-4">
-              ${createDeviceCards(devices, isFirst ? 'border-green-400' : 'border-blue-400')}
-            </div>
+      return `
+        <div class="relative border-4 ${subnet.panelClasses} rounded-2xl bg-gradient-to-b overflow-hidden min-h-[420px]">
+          <div class="absolute top-4 left-4 bg-white/90 border border-slate-200 rounded-lg px-4 py-2 shadow-sm z-30">
+            <p class="font-bold text-gray-800 text-sm">${subnet.title}</p>
+            <p class="text-xs text-gray-600">${subnet.mask}</p>
+            <p class="text-xs text-gray-500">${subnet.hostsLabel}</p>
+          </div>
 
-            <div class="mt-3 text-center">
-              <span class="inline-flex items-center gap-1 ${badgeColor} px-3 py-1 rounded-full text-xs font-semibold">${wifiEmoji} Lokalt broadcast</span>
+          <div class="absolute left-1/2 -translate-x-1/2 top-20 bg-slate-900 text-white border-4 border-slate-800 rounded-2xl px-6 py-3 shadow-2xl z-40">
+            <p class="text-xs font-bold text-center tracking-[0.35em]">SWITCH ${subnet.id}</p>
+            <div class="flex gap-1 justify-center mt-2">${switchPorts}</div>
+          </div>
+
+          <svg id="${subnet.svgId}" class="absolute inset-0 w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none">
+            <g data-layer="lines"></g>
+            <g data-layer="packets"></g>
+          </svg>
+
+          <div class="absolute w-full" style="top: 182px;">
+            <div class="grid grid-cols-3 gap-4 px-6">
+              ${deviceGrid}
             </div>
           </div>
-        `}
-    </div>
-  `;
-}
 
-function renderStep1() {
+          <div class="absolute left-0 right-0 bottom-6 text-center z-30">
+            <span class="inline-flex items-center gap-1 ${subnet.badgeClasses} px-3 py-1 rounded-full text-xs font-semibold">📶 Lokalt broadcast</span>
+          </div>
+        </div>
+      `;
+    })
+    .join('');
+
   visualizationEl.innerHTML = `
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 min-h-[500px]">
-      ${renderSubnetColumn(1)}
-      ${renderSubnetColumn(2)}
+    <div class="relative min-h-[560px]">
+      <div class="absolute left-1/2 -translate-x-1/2 top-6 z-40 text-center">
+        <div class="bg-slate-900 text-white border-4 border-slate-700 rounded-2xl px-8 py-4 shadow-2xl">
+          <p class="text-sm font-bold tracking-[0.45em]">ROUTER</p>
+          <div class="flex gap-1 justify-center mt-2">${routerPorts}</div>
+        </div>
+        <span class="mt-2 inline-block bg-white/90 text-xs font-semibold text-slate-600 px-3 py-1 rounded-full shadow-sm">Forbinder subnettene</span>
+      </div>
+
+      <svg class="absolute inset-0 w-full h-full pointer-events-none" viewBox="0 0 100 100" preserveAspectRatio="none">
+        <line x1="50" y1="24" x2="25" y2="40" stroke="#475569" stroke-width="2.2" stroke-linecap="round" stroke-dasharray="4 4"></line>
+        <line x1="50" y1="24" x2="75" y2="40" stroke="#475569" stroke-width="2.2" stroke-linecap="round" stroke-dasharray="4 4"></line>
+      </svg>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 pt-40">
+        ${panels}
+      </div>
     </div>
   `;
 
-  visualizationEl.querySelectorAll('[data-action="toggle-subnet"]').forEach((button) => {
-    button.addEventListener('click', () => {
-      const target = Number(button.getAttribute('data-target'));
-      if (target === 1) {
-        state.subnet1Collapsed = !state.subnet1Collapsed;
-      } else {
-        state.subnet2Collapsed = !state.subnet2Collapsed;
-      }
-      renderStep1();
+  subnets.forEach((subnet) => {
+    setupSubnetScene({
+      svgId: subnet.svgId,
+      devices: subnet.devices,
+      switchX: 50,
+      switchY: 30,
+      lineColor: subnet.lineColor,
+      packetColor: subnet.packetColor
     });
   });
 }
@@ -592,6 +643,142 @@ function renderVisualization() {
   }
 }
 
+function setupSubnetScene({ svgId, devices, switchX, switchY, lineColor, packetColor }) {
+  const svg = document.getElementById(svgId);
+  if (!svg) {
+    return;
+  }
+
+  const lineLayer = svg.querySelector('[data-layer="lines"]');
+  const packetLayer = svg.querySelector('[data-layer="packets"]');
+
+  if (!lineLayer || !packetLayer) {
+    return;
+  }
+
+  lineLayer.innerHTML = '';
+  packetLayer.innerHTML = '';
+
+  devices.forEach((_, index) => {
+    const { x, y } = getSubnetDevicePosition(index);
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', x);
+    line.setAttribute('y1', y);
+    line.setAttribute('x2', switchX);
+    line.setAttribute('y2', switchY);
+    line.setAttribute('stroke', lineColor);
+    line.setAttribute('stroke-width', '1.6');
+    line.setAttribute('stroke-linecap', 'round');
+    line.setAttribute('opacity', '0.65');
+    lineLayer.appendChild(line);
+  });
+
+  const toSwitchPackets = [];
+  const fromSwitchPackets = [];
+
+  const generator = setInterval(() => {
+    const fromIndex = Math.floor(Math.random() * devices.length);
+    const startPos = getSubnetDevicePosition(fromIndex);
+
+    const packetElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    packetElement.setAttribute('r', '2.4');
+    packetElement.setAttribute('class', 'packet');
+    packetElement.setAttribute('fill', packetColor);
+    packetElement.setAttribute('cx', startPos.x);
+    packetElement.setAttribute('cy', startPos.y);
+    packetLayer.appendChild(packetElement);
+
+    const availableTargets = devices
+      .map((_, idx) => idx)
+      .filter((idx) => idx !== fromIndex);
+    for (let i = availableTargets.length - 1; i > 0; i -= 1) {
+      const swapIndex = Math.floor(Math.random() * (i + 1));
+      const temp = availableTargets[i];
+      availableTargets[i] = availableTargets[swapIndex];
+      availableTargets[swapIndex] = temp;
+    }
+
+    const fanOut = Math.min(4, availableTargets.length);
+    const targets = availableTargets.slice(0, fanOut);
+
+    toSwitchPackets.push({
+      element: packetElement,
+      progress: 0,
+      startPos,
+      targets
+    });
+
+    if (toSwitchPackets.length > 5) {
+      const removed = toSwitchPackets.shift();
+      if (removed && removed.element && removed.element.parentNode) {
+        removed.element.parentNode.removeChild(removed.element);
+      }
+    }
+  }, 1200);
+
+  const animator = setInterval(() => {
+    for (let i = toSwitchPackets.length - 1; i >= 0; i -= 1) {
+      const packet = toSwitchPackets[i];
+      const nextProgress = packet.progress + 0.05;
+      packet.progress = nextProgress;
+
+      if (nextProgress >= 1) {
+        if (packet.element.parentNode) {
+          packet.element.parentNode.removeChild(packet.element);
+        }
+        toSwitchPackets.splice(i, 1);
+
+        packet.targets.forEach((targetIndex) => {
+          const targetPos = getSubnetDevicePosition(targetIndex);
+          const clone = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+          clone.setAttribute('r', '2');
+          clone.setAttribute('class', 'packet active');
+          clone.setAttribute('fill', packetColor);
+          clone.setAttribute('cx', switchX);
+          clone.setAttribute('cy', switchY);
+          packetLayer.appendChild(clone);
+
+          fromSwitchPackets.push({
+            element: clone,
+            progress: 0,
+            targetPos
+          });
+        });
+
+        continue;
+      }
+
+      const x = packet.startPos.x + (switchX - packet.startPos.x) * nextProgress;
+      const y = packet.startPos.y + (switchY - packet.startPos.y) * nextProgress;
+      packet.element.setAttribute('cx', x);
+      packet.element.setAttribute('cy', y);
+      packet.element.classList.add('active');
+    }
+
+    for (let i = fromSwitchPackets.length - 1; i >= 0; i -= 1) {
+      const packet = fromSwitchPackets[i];
+      const nextProgress = packet.progress + 0.06;
+      packet.progress = nextProgress;
+
+      if (nextProgress >= 1) {
+        if (packet.element.parentNode) {
+          packet.element.parentNode.removeChild(packet.element);
+        }
+        fromSwitchPackets.splice(i, 1);
+        continue;
+      }
+
+      const x = switchX + (packet.targetPos.x - switchX) * nextProgress;
+      const y = switchY + (packet.targetPos.y - switchY) * nextProgress;
+      packet.element.setAttribute('cx', x);
+      packet.element.setAttribute('cy', y);
+    }
+  }, 60);
+
+  subnetGenerators.push(generator);
+  subnetAnimators.push(animator);
+}
+
 function setupBroadcastScene() {
   const svg = document.getElementById('broadcast-svg');
   if (!svg) {
@@ -614,6 +801,7 @@ function setupBroadcastScene() {
     line.setAttribute('y2', '12');
     line.setAttribute('stroke', '#9ca3af');
     line.setAttribute('stroke-width', '1.8');
+    line.setAttribute('stroke-linecap', 'round');
     lineLayer.appendChild(line);
   });
 
@@ -704,8 +892,6 @@ prevBtn.addEventListener('click', () => {
 nextBtn.addEventListener('click', () => {
   if (state.step === steps.length - 1) {
     state.step = 0;
-    state.subnet1Collapsed = false;
-    state.subnet2Collapsed = false;
     state.calculationMode = 'subnets';
     state.customSubnets = 2;
     state.customHosts = 126;

--- a/assets/app.js
+++ b/assets/app.js
@@ -544,56 +544,7 @@ function renderStep0() {
   const deviceGrid = createDeviceCards(originalDevices);
 
   visualizationEl.innerHTML = `
-    <div class="tutorial-grid">
-      <article class="tutorial-panel">
-        <header class="tutorial-panel__header">
-          <p class="tutorial-panel__kicker">Hej hold!</p>
-          <h2 class="tutorial-panel__title">Hvorfor skal vi lære subnetting?</h2>
-        </header>
-        <p>
-          Når vi samler alle maskiner i ét <button type="button" class="term-button" data-term="LAN" data-context="Definér begrebet Local Area Network for elever på et grundforløb og giv et letforståeligt eksempel.">lokalt netværk</button>,
-          råber hver enhed ud i rummet, når den sender en <button type="button" class="term-button" data-term="Broadcast" data-context="Forklar hvad broadcast betyder i et LAN, hvorfor det kan skabe støj, og hvordan det opleves af nye elever.">broadcast</button>.
-          På et Grundforløb betyder det langsomme filer, nervøse printere og elever der mister fokus. Som underviser er mit mål, at I kan se problemet og selv foreslå en løsning.
-        </p>
-        <section class="tutorial-section">
-          <h3>Udfordringen i værkstedet</h3>
-          <p>
-            Forestil jer vores Techcollege Makerspace: 24 pc'er, en 3D-printer og nogle tablets. Alt er sat i ét netværk <span class="tutorial-highlight">192.168.1.0/24</span>.
-            Når en elev spejler sin skærm, ender signalet hos alle andre – uanset om de har brug for det eller ej. Det slider på både udstyr og tålmodighed.
-          </p>
-          <ul class="tutorial-list">
-            <li>Mere unødvendig trafik = langsommere svar fra servere.</li>
-            <li>Fejl ét sted kan smitte hele netværket.</li>
-            <li>Det er svært at finde ud af, hvem der skaber støjen.</li>
-          </ul>
-        </section>
-        <section class="tutorial-section">
-          <h3>Løsningen vi arbejder hen imod</h3>
-          <p>
-            Vi deler netværket i mindre <button type="button" class="term-button" data-term="Subnet" data-context="Forklar hvad et subnet er, og hvordan det hjælper med at reducere broadcast-trafik. Brug et pædagogisk hverdagseksempel.">subnets</button>. Hvert subnet er som sin egen klasse – roligere og lettere at styre.
-            I dag undersøger vi, hvordan <button type="button" class="term-button" data-term="CIDR" data-context="Forklar Classless Inter-Domain Routing kort og i et sprog som en Grundforløbselev kan forstå. Giv et nemt eksempel.">CIDR-notation</button>
-            og en ny <button type="button" class="term-button" data-term="Subnetmaske" data-context="Forklar hvad en subnetmaske er, hvordan man læser den, og hvorfor den er vigtig når man opdeler netværk.">subnetmaske</button> hjælper os med at låne bits fra host-delen.
-          </p>
-          <p>
-            Når vi har delt os i to grupper, sørger en <button type="button" class="term-button" data-term="Gateway" data-context="Forklar gateway-begrebet for en ny elev og hvorfor den er nødvendig når vi forbinder flere subnets.">gateway</button> eller router for at sende trafikken de rigtige steder hen.
-          </p>
-        </section>
-        <section class="tutorial-section">
-          <h3>Sådan gør vi i fællesskab</h3>
-          <ol class="tutorial-steps">
-            <li>Observer den massive broadcast-trafik i animationen til højre.</li>
-            <li>Diskutér i grupper hvorfor det er et problem for vores elever og udstyr.</li>
-            <li>Lav en hurtig skitse af, hvordan to subnets kunne fordeles i jeres praksis.</li>
-            <li>Brug beregneren i trin 5 til at teste jeres idéer.</li>
-          </ol>
-        </section>
-        <footer class="tutorial-panel__footer">
-          <p>
-            Husk: subnetting handler ikke kun om tal – det handler om at give vores læringsmiljø ro. Stil spørgsmål, klik på fagordene for ekstra forklaringer, og vær nysgerrige!
-          </p>
-        </footer>
-      </article>
-
+    <div class="step0-stack">
       <div class="relative min-h-[500px] tutorial-visual">
         <div class="border-4 border-red-400 rounded-xl p-4 md:p-6 bg-red-50 relative overflow-hidden min-h-[500px]">
           <div class="callout-box absolute top-4 left-4 z-10">
@@ -631,6 +582,97 @@ function renderStep0() {
           <p class="text-sm text-gray-700">"Vi har et problem! Alt for meget broadcast-trafik gennem switchen. Vi skal opdele netværket i mindre subnets!"</p>
         </div>
       </div>
+      <article class="tutorial-panel tutorial-panel--stacked">
+        <header class="tutorial-panel__header">
+          <p class="tutorial-panel__kicker">Grundforløb – lektion 1</p>
+          <h2 class="tutorial-panel__title">Introduktion til subnetting</h2>
+        </header>
+        <p>
+          I dag arbejder vi sammen om at forstå, hvorfor vi opdeler et netværk. Forestil jer, at hele værkstedet kun er forbundet via ét
+          <button type="button" class="term-button" data-term="LAN" data-context="Definér begrebet Local Area Network for elever på et grundforløb og giv et letforståeligt eksempel.">LAN</button>.
+          Når nogen sender en besked, hører alle den. Det kan være hyggeligt, men det bliver hurtigt larm. Subnetting er teknikken, der hjælper os med at styre den larm.
+        </p>
+        <div class="tutorial-scroll">
+          <section class="tutorial-section">
+            <h3>1. Hvad er en IP-adresse?</h3>
+            <p>
+              Hver computer får en unik <button type="button" class="term-button" data-term="IP-adresse" data-context="Forklar hvad en IPv4-adresse er, hvorfor den har fire tal, og hvordan elever kan læse den.">IP-adresse</button>, fx
+              <span class="tutorial-highlight">192.168.1.23</span>. De første tal fortæller, hvilket område vi er i, og de sidste tal peger på den konkrete enhed. Vi kalder det
+              <button type="button" class="term-button" data-term="Netværksdel" data-context="Forklar forskellen på netværksdel og hostdel i et sprog der passer til grundforløbs-elever.">netværksdel</button>
+              og <button type="button" class="term-button" data-term="Hostdel" data-context="Forklar hvad hostdelen er i en IPv4-adresse og hvorfor den begrænser hvor mange enheder der kan være i et subnet.">hostdel</button>.
+            </p>
+            <ul class="tutorial-list">
+              <li><strong>Netværksdel:</strong> hvem er med i gruppen?</li>
+              <li><strong>Hostdel:</strong> hvilken elev i gruppen taler vi med?</li>
+              <li><strong>Eksempel:</strong> 192.168.1.<em>x</em> – de tre første tal er fælles, det sidste <em>x</em> skifter mellem 1 og 254.</li>
+            </ul>
+          </section>
+          <section class="tutorial-section">
+            <h3>2. Hvorfor bliver der larm?</h3>
+            <p>
+              Når en enhed sender en <button type="button" class="term-button" data-term="Broadcast" data-context="Forklar hvad broadcast betyder i et LAN, hvorfor det kan skabe støj, og hvordan det opleves af nye elever.">broadcast</button>,
+              spørger den: “Er du der?” til alle på én gang. På små hold er det fint, men med 24 pc'er, printere og IoT-enheder betyder det mange afbrydelser.
+            </p>
+            <div class="tutorial-callout">
+              <p><strong>Konsekvens:</strong> Filer åbner langsomt, og fejlsøgning bliver svært, fordi alle ser hinandens beskeder.</p>
+              <p><strong>Observation:</strong> Kig på animationen ovenfor og bemærk, hvordan hver rød pakke rammer alle maskiner.</p>
+            </div>
+          </section>
+          <section class="tutorial-section">
+            <h3>3. Hvad gør subnetting?</h3>
+            <p>
+              Subnetting betyder, at vi deler hostdelen op i mindre grupper ved hjælp af en
+              <button type="button" class="term-button" data-term="Subnetmaske" data-context="Forklar hvad en subnetmaske er, hvordan man læser den, og hvorfor den er vigtig når man opdeler netværk.">subnetmaske</button>.
+              Vi “låner” bits fra hostdelen til netværksdelen, så vi får flere grupper men færre pladser i hver gruppe.
+            </p>
+            <ol class="tutorial-steps">
+              <li>Start med et <span class="tutorial-highlight">/24</span>-netværk (255.255.255.0) – 254 mulige enheder.</li>
+              <li>Lån én bit → <span class="tutorial-highlight">/25</span> (255.255.255.128) – nu har vi to grupper med plads til 126 enheder hver.</li>
+              <li>Hver gruppe får sin egen <button type="button" class="term-button" data-term="Gateway" data-context="Forklar gateway-begrebet for en ny elev og hvorfor den er nødvendig når vi forbinder flere subnets.">gateway</button> for at tale med resten af verden.</li>
+            </ol>
+          </section>
+          <section class="tutorial-section">
+            <h3>4. Eksempel fra vores værksted</h3>
+            <p>
+              Vi deler 24 pc'er i to hold:
+            </p>
+            <ul class="tutorial-list">
+              <li><strong>Subnet 1:</strong> 192.168.1.0 – 192.168.1.127 til teori-lokalet.</li>
+              <li><strong>Subnet 2:</strong> 192.168.1.128 – 192.168.1.255 til værkstedet.</li>
+              <li>Begge subnets taler med en fælles router, men <em>broadcasts</em> bliver i deres egen gruppe.</li>
+            </ul>
+            <p>
+              Resultatet er roligere netværk, hurtigere svar fra serverne og lettere fejlsøgning.
+            </p>
+          </section>
+          <section class="tutorial-section">
+            <h3>5. Sådan øver vi os</h3>
+            <p>
+              Følg disse aktiviteter i klassen:
+            </p>
+            <ol class="tutorial-steps">
+              <li>Notér hvilke enheder der er vigtige i jeres lokale. Hvor mange adresser skal de bruge?</li>
+              <li>Brug beregneren i trin 5 til at finde et subnet, der passer til jeres tal.</li>
+              <li>Sammenlign jeres svar med makkeren og forklar forskellen.</li>
+              <li>Test viden i opgavebanken på trin 6 – klik på “Vis forklaring”, hvis I går i stå.</li>
+            </ol>
+          </section>
+          <section class="tutorial-section">
+            <h3>6. Opsummering før vi går videre</h3>
+            <p>
+              Subnetting hjælper os med at holde styr på trafikken, beskytte udstyr og skabe et godt læringsmiljø. Klik på fagordene, hvis noget er uklart – AI-assistenten giver en kort forklaring målrettet jer som Grundforløbshold.
+            </p>
+            <p>
+              Når I er klar, går vi videre til næste trin og ser, hvordan netværket ændrer sig i praksis.
+            </p>
+          </section>
+        </div>
+        <footer class="tutorial-panel__footer">
+          <p>
+            Spørgsmål er velkomne! Jo bedre vi forstår grundideen, desto nemmere bliver resten af forløbet.
+          </p>
+        </footer>
+      </article>
     </div>
   `;
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -87,6 +87,15 @@ let routerTrafficGenerators = [];
 let routerTrafficAnimators = [];
 let routerTrafficCleanups = [];
 let tasksPromise = null;
+let termOverlayElement = null;
+let termOverlayDialog = null;
+let termOverlayTitle = null;
+let termOverlayBody = null;
+let termOverlayCloseButton = null;
+let termOverlayBackdrop = null;
+let termOverlayLastFocus = null;
+let termOverlayKeyHandlerBound = false;
+const termExplanationCache = new Map();
 
 function getDevicePosition(index) {
   const row = Math.floor(index / 6);
@@ -176,6 +185,177 @@ function escapeHtml(value) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+function formatExplanationText(value) {
+  const safe = escapeHtml(typeof value === 'string' ? value : '');
+  if (safe === '') {
+    return '<p class="term-overlay__empty">Ingen forklaring tilgængelig.</p>';
+  }
+
+  return safe
+    .split(/\n{2,}/)
+    .map((block) => `<p>${block.replace(/\n/g, '<br>')}</p>`)
+    .join('');
+}
+
+function handleTermOverlayKeydown(event) {
+  if (event.key === 'Escape' && termOverlayElement && termOverlayElement.classList.contains('visible')) {
+    event.preventDefault();
+    closeTermOverlay();
+  }
+}
+
+function ensureTermOverlay() {
+  if (termOverlayElement) {
+    return;
+  }
+
+  termOverlayElement = document.createElement('div');
+  termOverlayElement.id = 'term-overlay';
+  termOverlayElement.className = 'term-overlay';
+  termOverlayElement.setAttribute('aria-hidden', 'true');
+  termOverlayElement.innerHTML = `
+    <div class="term-overlay__backdrop" data-overlay-close></div>
+    <div class="term-overlay__dialog" role="dialog" aria-modal="true" aria-labelledby="term-overlay-title">
+      <button type="button" class="term-overlay__close" aria-label="Luk forklaring" data-overlay-close>&times;</button>
+      <h3 id="term-overlay-title" class="term-overlay__title"></h3>
+      <div class="term-overlay__body"></div>
+    </div>
+  `;
+
+  document.body.appendChild(termOverlayElement);
+
+  termOverlayDialog = termOverlayElement.querySelector('.term-overlay__dialog');
+  termOverlayTitle = termOverlayElement.querySelector('#term-overlay-title');
+  termOverlayBody = termOverlayElement.querySelector('.term-overlay__body');
+  termOverlayCloseButton = termOverlayElement.querySelector('.term-overlay__close');
+  termOverlayBackdrop = termOverlayElement.querySelector('.term-overlay__backdrop');
+
+  const closers = termOverlayElement.querySelectorAll('[data-overlay-close]');
+  closers.forEach((closer) => {
+    closer.addEventListener('click', () => {
+      closeTermOverlay();
+    });
+  });
+
+  if (!termOverlayKeyHandlerBound) {
+    document.addEventListener('keydown', handleTermOverlayKeydown);
+    termOverlayKeyHandlerBound = true;
+  }
+}
+
+function closeTermOverlay() {
+  if (!termOverlayElement) {
+    return;
+  }
+
+  termOverlayElement.classList.remove('visible');
+  termOverlayElement.setAttribute('aria-hidden', 'true');
+
+  if (termOverlayDialog) {
+    termOverlayDialog.setAttribute('aria-busy', 'false');
+  }
+
+  document.body.classList.remove('term-overlay-open');
+
+  if (termOverlayLastFocus && typeof termOverlayLastFocus.focus === 'function') {
+    termOverlayLastFocus.focus();
+  }
+
+  termOverlayLastFocus = null;
+}
+
+function openTermOverlay(term, context) {
+  ensureTermOverlay();
+
+  const trimmedTerm = typeof term === 'string' && term.trim() !== '' ? term.trim() : 'Forklaring';
+  const trimmedContext = typeof context === 'string' ? context.trim() : '';
+  const cacheKey = `${trimmedTerm}::${trimmedContext}`;
+
+  termOverlayLastFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+  if (termOverlayTitle) {
+    termOverlayTitle.textContent = trimmedTerm;
+  }
+
+  if (termOverlayBody) {
+    termOverlayBody.innerHTML = '<p class="term-overlay__loading">Henter forklaring...</p>';
+  }
+
+  if (termOverlayDialog) {
+    termOverlayDialog.setAttribute('aria-busy', 'true');
+  }
+
+  termOverlayElement.classList.add('visible');
+  termOverlayElement.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('term-overlay-open');
+
+  if (termOverlayCloseButton) {
+    termOverlayCloseButton.focus();
+  }
+
+  if (termExplanationCache.has(cacheKey)) {
+    if (termOverlayBody) {
+      termOverlayBody.innerHTML = formatExplanationText(termExplanationCache.get(cacheKey));
+    }
+    if (termOverlayDialog) {
+      termOverlayDialog.setAttribute('aria-busy', 'false');
+    }
+    return;
+  }
+
+  fetch('api/explain-term.php', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      term: trimmedTerm,
+      context: trimmedContext
+    })
+  })
+    .then((response) => response.json().catch(() => ({ error: 'Uventet svar fra serveren.' })))
+    .then((data) => {
+      if (!termOverlayBody) {
+        return;
+      }
+
+      if (!data || data.error) {
+        const message = data && data.error ? data.error : 'Der opstod en fejl under opslaget.';
+        termOverlayBody.innerHTML = `<p class="term-overlay__error">${escapeHtml(message)}</p>`;
+      } else {
+        const explanation = typeof data.explanation === 'string' ? data.explanation : '';
+        termExplanationCache.set(cacheKey, explanation);
+        termOverlayBody.innerHTML = formatExplanationText(explanation);
+      }
+
+      if (termOverlayDialog) {
+        termOverlayDialog.setAttribute('aria-busy', 'false');
+      }
+    })
+    .catch((error) => {
+      if (!termOverlayBody) {
+        return;
+      }
+      const message = error instanceof Error ? error.message : 'Der opstod en ukendt fejl under opslaget.';
+      termOverlayBody.innerHTML = `<p class="term-overlay__error">${escapeHtml(message)}</p>`;
+      if (termOverlayDialog) {
+        termOverlayDialog.setAttribute('aria-busy', 'false');
+      }
+    });
+}
+
+function setupTutorialTerms() {
+  const termButtons = visualizationEl.querySelectorAll('.term-button');
+  termButtons.forEach((button) => {
+    button.setAttribute('aria-haspopup', 'dialog');
+    button.addEventListener('click', () => {
+      const term = button.getAttribute('data-term') || button.textContent || '';
+      const context = button.getAttribute('data-context') || '';
+      openTermOverlay(term, context);
+    });
+  });
 }
 
 function calculateSubnetting() {
@@ -364,46 +544,98 @@ function renderStep0() {
   const deviceGrid = createDeviceCards(originalDevices);
 
   visualizationEl.innerHTML = `
-    <div class="relative min-h-[500px]">
-      <div class="border-4 border-red-400 rounded-xl p-4 md:p-6 bg-red-50 relative overflow-hidden min-h-[500px]">
-        <div class="callout-box absolute top-4 left-4 z-10">
-          <p class="font-bold text-gray-800">Netværk: 192.168.1.0/24</p>
-          <p class="text-gray-600">Subnet mask: 255.255.255.0</p>
-          <p class="text-gray-500">× 24 enheder</p>
-        </div>
+    <div class="tutorial-grid">
+      <article class="tutorial-panel">
+        <header class="tutorial-panel__header">
+          <p class="tutorial-panel__kicker">Hej hold!</p>
+          <h2 class="tutorial-panel__title">Hvorfor skal vi lære subnetting?</h2>
+        </header>
+        <p>
+          Når vi samler alle maskiner i ét <button type="button" class="term-button" data-term="LAN" data-context="Definér begrebet Local Area Network for elever på et grundforløb og giv et letforståeligt eksempel.">lokalt netværk</button>,
+          råber hver enhed ud i rummet, når den sender en <button type="button" class="term-button" data-term="Broadcast" data-context="Forklar hvad broadcast betyder i et LAN, hvorfor det kan skabe støj, og hvordan det opleves af nye elever.">broadcast</button>.
+          På et Grundforløb betyder det langsomme filer, nervøse printere og elever der mister fokus. Som underviser er mit mål, at I kan se problemet og selv foreslå en løsning.
+        </p>
+        <section class="tutorial-section">
+          <h3>Udfordringen i værkstedet</h3>
+          <p>
+            Forestil jer vores Techcollege Makerspace: 24 pc'er, en 3D-printer og nogle tablets. Alt er sat i ét netværk <span class="tutorial-highlight">192.168.1.0/24</span>.
+            Når en elev spejler sin skærm, ender signalet hos alle andre – uanset om de har brug for det eller ej. Det slider på både udstyr og tålmodighed.
+          </p>
+          <ul class="tutorial-list">
+            <li>Mere unødvendig trafik = langsommere svar fra servere.</li>
+            <li>Fejl ét sted kan smitte hele netværket.</li>
+            <li>Det er svært at finde ud af, hvem der skaber støjen.</li>
+          </ul>
+        </section>
+        <section class="tutorial-section">
+          <h3>Løsningen vi arbejder hen imod</h3>
+          <p>
+            Vi deler netværket i mindre <button type="button" class="term-button" data-term="Subnet" data-context="Forklar hvad et subnet er, og hvordan det hjælper med at reducere broadcast-trafik. Brug et pædagogisk hverdagseksempel.">subnets</button>. Hvert subnet er som sin egen klasse – roligere og lettere at styre.
+            I dag undersøger vi, hvordan <button type="button" class="term-button" data-term="CIDR" data-context="Forklar Classless Inter-Domain Routing kort og i et sprog som en Grundforløbselev kan forstå. Giv et nemt eksempel.">CIDR-notation</button>
+            og en ny <button type="button" class="term-button" data-term="Subnetmaske" data-context="Forklar hvad en subnetmaske er, hvordan man læser den, og hvorfor den er vigtig når man opdeler netværk.">subnetmaske</button> hjælper os med at låne bits fra host-delen.
+          </p>
+          <p>
+            Når vi har delt os i to grupper, sørger en <button type="button" class="term-button" data-term="Gateway" data-context="Forklar gateway-begrebet for en ny elev og hvorfor den er nødvendig når vi forbinder flere subnets.">gateway</button> eller router for at sende trafikken de rigtige steder hen.
+          </p>
+        </section>
+        <section class="tutorial-section">
+          <h3>Sådan gør vi i fællesskab</h3>
+          <ol class="tutorial-steps">
+            <li>Observer den massive broadcast-trafik i animationen til højre.</li>
+            <li>Diskutér i grupper hvorfor det er et problem for vores elever og udstyr.</li>
+            <li>Lav en hurtig skitse af, hvordan to subnets kunne fordeles i jeres praksis.</li>
+            <li>Brug beregneren i trin 5 til at teste jeres idéer.</li>
+          </ol>
+        </section>
+        <footer class="tutorial-panel__footer">
+          <p>
+            Husk: subnetting handler ikke kun om tal – det handler om at give vores læringsmiljø ro. Stil spørgsmål, klik på fagordene for ekstra forklaringer, og vær nysgerrige!
+          </p>
+        </footer>
+      </article>
 
-        <div class="absolute left-1/2 -translate-x-1/2 top-12 bg-gray-800 text-white rounded-lg border-4 border-gray-900 shadow-2xl px-10 py-3 z-20">
-          <div class="font-bold text-sm text-center mb-2 tracking-widest">LAN SWITCH</div>
-          <div class="flex gap-1 justify-center">
-            ${Array.from({ length: 12 })
-              .map(() => '<span class="block w-2 h-6 bg-green-400 rounded"></span>')
-              .join('')}
+      <div class="relative min-h-[500px] tutorial-visual">
+        <div class="border-4 border-red-400 rounded-xl p-4 md:p-6 bg-red-50 relative overflow-hidden min-h-[500px]">
+          <div class="callout-box absolute top-4 left-4 z-10">
+            <p class="font-bold text-gray-800">Netværk: 192.168.1.0/24</p>
+            <p class="text-gray-600">Subnet mask: 255.255.255.0</p>
+            <p class="text-gray-500">× 24 enheder</p>
           </div>
-        </div>
 
-        <svg id="broadcast-svg" class="absolute inset-0 w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none">
-          <g id="line-layer"></g>
-          <g id="packet-layer"></g>
-        </svg>
-
-        <div class="absolute w-full" style="top: 160px;" id="device-wrapper">
-          <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4 px-4">
-            ${deviceGrid}
+          <div class="absolute left-1/2 -translate-x-1/2 top-12 bg-gray-800 text-white rounded-lg border-4 border-gray-900 shadow-2xl px-10 py-3 z-20">
+            <div class="font-bold text-sm text-center mb-2 tracking-widest">LAN SWITCH</div>
+            <div class="flex gap-1 justify-center">
+              ${Array.from({ length: 12 })
+                .map(() => '<span class="block w-2 h-6 bg-green-400 rounded"></span>')
+                .join('')}
+            </div>
           </div>
+
+          <svg id="broadcast-svg" class="absolute inset-0 w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none">
+            <g id="line-layer"></g>
+            <g id="packet-layer"></g>
+          </svg>
+
+          <div class="absolute w-full" style="top: 160px;" id="device-wrapper">
+            <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4 px-4">
+              ${deviceGrid}
+            </div>
+          </div>
+
+          <div class="absolute bottom-6 right-6 text-6xl">⚠️</div>
         </div>
 
-        <div class="absolute bottom-6 right-6 text-6xl">⚠️</div>
-      </div>
-
-      <div id="chef-popup" class="hidden absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white border-4 border-indigo-600 rounded-xl p-6 shadow-2xl max-w-sm z-30">
-        <div class="text-4xl mb-3 text-center">👨‍💼</div>
-        <p class="text-lg font-bold text-gray-800 mb-2">Netværksadministrator:</p>
-        <p class="text-sm text-gray-700">"Vi har et problem! Alt for meget broadcast-trafik gennem switchen. Vi skal opdele netværket i mindre subnets!"</p>
+        <div id="chef-popup" class="hidden absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white border-4 border-indigo-600 rounded-xl p-6 shadow-2xl max-w-sm z-30">
+          <div class="text-4xl mb-3 text-center">👨‍💼</div>
+          <p class="text-lg font-bold text-gray-800 mb-2">Netværksadministrator:</p>
+          <p class="text-sm text-gray-700">"Vi har et problem! Alt for meget broadcast-trafik gennem switchen. Vi skal opdele netværket i mindre subnets!"</p>
+        </div>
       </div>
     </div>
   `;
 
   setupBroadcastScene();
+  setupTutorialTerms();
 }
 
 function renderStep1() {

--- a/assets/app.js
+++ b/assets/app.js
@@ -56,6 +56,9 @@ let broadcastPackets = [];
 let chefTimer = null;
 let subnetGenerators = [];
 let subnetAnimators = [];
+let routerTrafficGenerators = [];
+let routerTrafficAnimators = [];
+let routerTrafficCleanups = [];
 
 function getDevicePosition(index) {
   const row = Math.floor(index / 6);
@@ -156,6 +159,12 @@ function cleanupStep() {
   subnetAnimators.forEach((interval) => clearInterval(interval));
   subnetGenerators = [];
   subnetAnimators = [];
+  routerTrafficGenerators.forEach((interval) => clearInterval(interval));
+  routerTrafficAnimators.forEach((interval) => clearInterval(interval));
+  routerTrafficCleanups.forEach((cleanup) => cleanup());
+  routerTrafficGenerators = [];
+  routerTrafficAnimators = [];
+  routerTrafficCleanups = [];
 }
 
 function setStep(newStep) {
@@ -355,12 +364,15 @@ function renderStep1() {
           <p class="text-sm font-bold tracking-[0.45em]">ROUTER</p>
           <div class="flex gap-1 justify-center mt-2">${routerPorts}</div>
         </div>
-        <span class="mt-2 inline-block bg-white/90 text-xs font-semibold text-slate-600 px-3 py-1 rounded-full shadow-sm">Forbinder subnettene</span>
+        <div class="mt-2 flex flex-col items-center gap-1">
+          <span class="inline-block bg-white/90 text-xs font-semibold text-slate-600 px-3 py-1 rounded-full shadow-sm">Forbinder subnettene</span>
+          <span class="inline-block bg-emerald-50/90 text-[11px] font-semibold text-emerald-700 px-3 py-1 rounded-full shadow-sm">Router stopper broadcast til andre LAN</span>
+        </div>
       </div>
 
       <svg class="absolute inset-0 w-full h-full pointer-events-none router-link-layer" viewBox="0 0 100 100" preserveAspectRatio="none">
-        <path d="M50 26 C44 32 38 36 34 42" stroke="#14b8a6" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.75" fill="none"></path>
-        <path d="M50 26 C56 32 62 36 66 42" stroke="#38bdf8" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.75" fill="none"></path>
+        <path id="router-path-left" d="M50 26 C44 32 38 36 34 42" stroke="#14b8a6" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.75" fill="none"></path>
+        <path id="router-path-right" d="M50 26 C56 32 62 36 66 42" stroke="#38bdf8" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.75" fill="none"></path>
         <circle cx="34" cy="42" r="1.5" fill="#0f766e" fill-opacity="0.8"></circle>
         <circle cx="66" cy="42" r="1.5" fill="#0369a1" fill-opacity="0.8"></circle>
       </svg>
@@ -380,6 +392,18 @@ function renderStep1() {
       lineColor: subnet.lineColor,
       packetColor: subnet.packetColor
     });
+  });
+
+  setupRouterTraffic({
+    pathId: 'router-path-left',
+    color: '#0f766e',
+    burstColor: '#14b8a6'
+  });
+
+  setupRouterTraffic({
+    pathId: 'router-path-right',
+    color: '#0369a1',
+    burstColor: '#38bdf8'
   });
 }
 
@@ -643,6 +667,106 @@ function renderVisualization() {
     default:
       visualizationEl.innerHTML = '';
   }
+}
+
+function setupRouterTraffic({ pathId, color, burstColor }) {
+  const path = document.getElementById(pathId);
+  if (!path) {
+    return;
+  }
+
+  const svg = path.ownerSVGElement;
+  if (!svg || typeof path.getTotalLength !== 'function') {
+    return;
+  }
+
+  const pathLength = path.getTotalLength();
+  const activePackets = [];
+
+  const spawnPacket = () => {
+    const packet = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    const startPoint = path.getPointAtLength(pathLength);
+    packet.setAttribute('r', '1.9');
+    packet.setAttribute('fill', color);
+    packet.setAttribute('cx', startPoint.x);
+    packet.setAttribute('cy', startPoint.y);
+    packet.setAttribute('class', 'router-packet');
+    svg.appendChild(packet);
+
+    activePackets.push({
+      element: packet,
+      progress: 0
+    });
+
+    if (activePackets.length > 6) {
+      const stale = activePackets.shift();
+      if (stale && stale.element && stale.element.parentNode) {
+        stale.element.parentNode.removeChild(stale.element);
+      }
+    }
+  };
+
+  const generator = setInterval(() => {
+    if (Math.random() < 0.6) {
+      spawnPacket();
+    }
+  }, 900);
+
+  const animator = setInterval(() => {
+    for (let i = activePackets.length - 1; i >= 0; i -= 1) {
+      const packet = activePackets[i];
+      const nextProgress = packet.progress + 0.05;
+      packet.progress = nextProgress;
+
+      const distance = Math.max(pathLength * (1 - nextProgress), 0);
+      const point = path.getPointAtLength(distance);
+      packet.element.setAttribute('cx', point.x);
+      packet.element.setAttribute('cy', point.y);
+      packet.element.classList.add('active');
+
+      if (nextProgress >= 1) {
+        if (packet.element.parentNode) {
+          packet.element.parentNode.removeChild(packet.element);
+        }
+        activePackets.splice(i, 1);
+
+        const routerPoint = path.getPointAtLength(0);
+        const burst = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        burst.setAttribute('cx', routerPoint.x);
+        burst.setAttribute('cy', routerPoint.y);
+        burst.setAttribute('r', '0.5');
+        burst.setAttribute('class', 'router-burst');
+        burst.setAttribute('stroke', burstColor || color);
+        burst.setAttribute('stroke-width', '1.4');
+        svg.appendChild(burst);
+
+        setTimeout(() => {
+          if (burst.parentNode) {
+            burst.parentNode.removeChild(burst);
+          }
+        }, 650);
+      }
+    }
+  }, 60);
+
+  const cleanup = () => {
+    for (let i = activePackets.length - 1; i >= 0; i -= 1) {
+      const packet = activePackets[i];
+      if (packet.element && packet.element.parentNode) {
+        packet.element.parentNode.removeChild(packet.element);
+      }
+    }
+    activePackets.length = 0;
+    svg.querySelectorAll('.router-burst').forEach((burst) => {
+      if (burst.parentNode) {
+        burst.parentNode.removeChild(burst);
+      }
+    });
+  };
+
+  routerTrafficGenerators.push(generator);
+  routerTrafficAnimators.push(animator);
+  routerTrafficCleanups.push(cleanup);
 }
 
 function setupSubnetScene({ svgId, devices, switchX, switchY, lineColor, packetColor }) {

--- a/assets/app.js
+++ b/assets/app.js
@@ -358,9 +358,11 @@ function renderStep1() {
         <span class="mt-2 inline-block bg-white/90 text-xs font-semibold text-slate-600 px-3 py-1 rounded-full shadow-sm">Forbinder subnettene</span>
       </div>
 
-      <svg class="absolute inset-0 w-full h-full pointer-events-none" viewBox="0 0 100 100" preserveAspectRatio="none">
-        <line x1="50" y1="24" x2="25" y2="40" stroke="#475569" stroke-width="2.2" stroke-linecap="round" stroke-dasharray="4 4"></line>
-        <line x1="50" y1="24" x2="75" y2="40" stroke="#475569" stroke-width="2.2" stroke-linecap="round" stroke-dasharray="4 4"></line>
+      <svg class="absolute inset-0 w-full h-full pointer-events-none router-link-layer" viewBox="0 0 100 100" preserveAspectRatio="none">
+        <path d="M50 26 C44 32 38 36 34 42" stroke="#14b8a6" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.75" fill="none"></path>
+        <path d="M50 26 C56 32 62 36 66 42" stroke="#38bdf8" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" stroke-opacity="0.75" fill="none"></path>
+        <circle cx="34" cy="42" r="1.5" fill="#0f766e" fill-opacity="0.8"></circle>
+        <circle cx="66" cy="42" r="1.5" fill="#0369a1" fill-opacity="0.8"></circle>
       </svg>
 
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 pt-40">

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,718 @@
+const progressEl = document.getElementById('progress');
+const visualizationEl = document.getElementById('visualization');
+const calculatorEl = document.getElementById('calculator');
+const prevBtn = document.getElementById('prev-step');
+const nextBtn = document.getElementById('next-step');
+const stepIndicator = document.getElementById('step-indicator');
+
+const steps = [
+  {
+    title: 'Problem: For meget broadcast-trafik!',
+    description: 'Alle enheder er på samme netværk (192.168.1.0/24) og modtager ALT broadcast-trafik.'
+  },
+  {
+    title: 'Efter subnetting: To separate netværk',
+    description: 'Broadcast-trafik er isoleret, fordi vi har opdelt netværket i to subnets.'
+  },
+  {
+    title: 'Beregning af subnet mask',
+    description: 'Vi ændrer masken fra /24 til /25 og låner 1 bit til subnetting.'
+  },
+  {
+    title: 'Resultat: Detaljeret visning',
+    description: 'Se gateway, broadcast og brugbare adresser for begge subnets.'
+  },
+  {
+    title: 'Prøv selv: Tilpas subnetting',
+    description: 'Eksperimenter med antal subnets eller hosts og se beregningerne opdatere med det samme.'
+  }
+];
+
+const originalDevices = Array.from({ length: 24 }, (_, i) => ({
+  id: i,
+  ip: `192.168.1.${i + 2}`
+}));
+
+const subnet1Devices = Array.from({ length: 12 }, (_, i) => ({
+  id: i,
+  ip: `192.168.1.${i + 1}`
+}));
+
+const subnet2Devices = Array.from({ length: 12 }, (_, i) => ({
+  id: i,
+  ip: `192.168.1.${129 + i}`
+}));
+
+const state = {
+  step: 0,
+  subnet1Collapsed: false,
+  subnet2Collapsed: false,
+  calculationMode: 'subnets',
+  customSubnets: 2,
+  customHosts: 126
+};
+
+let broadcastGenerator = null;
+let broadcastAnimator = null;
+let broadcastPackets = [];
+let chefTimer = null;
+
+function getDevicePosition(index) {
+  const row = Math.floor(index / 6);
+  const col = index % 6;
+  return {
+    x: 8 + col * 14.5,
+    y: 35 + row * 14
+  };
+}
+
+function calculateSubnetting() {
+  let subnetBits;
+  let numSubnets;
+  let hostsPerSubnet;
+
+  if (state.calculationMode === 'subnets') {
+    numSubnets = state.customSubnets;
+    subnetBits = Math.ceil(Math.log2(numSubnets));
+    hostsPerSubnet = Math.pow(2, 8 - subnetBits) - 2;
+  } else {
+    hostsPerSubnet = state.customHosts;
+    const hostBits = Math.ceil(Math.log2(hostsPerSubnet + 2));
+    subnetBits = 8 - hostBits;
+    if (subnetBits < 0) {
+      subnetBits = 0;
+    }
+    numSubnets = Math.pow(2, Math.max(subnetBits, 0));
+  }
+
+  if (subnetBits < 0) {
+    subnetBits = 0;
+  }
+
+  const newPrefix = 24 + subnetBits;
+  const subnetMaskLastOctet = 256 - Math.pow(2, 8 - subnetBits);
+  const blockSize = Math.pow(2, 8 - subnetBits);
+
+  const subnets = [];
+  for (let i = 0; i < numSubnets && i < 256; i += 1) {
+    const networkAddress = i * blockSize;
+    if (networkAddress > 255) {
+      break;
+    }
+
+    const firstHost = networkAddress + 1;
+    const lastHost = networkAddress + blockSize - 2;
+    const broadcast = networkAddress + blockSize - 1;
+
+    subnets.push({
+      id: i,
+      network: `192.168.1.${networkAddress}`,
+      firstHost: `192.168.1.${firstHost}`,
+      lastHost: `192.168.1.${lastHost}`,
+      broadcast: `192.168.1.${broadcast}`,
+      usableHosts: hostsPerSubnet,
+      prefix: newPrefix
+    });
+  }
+
+  return {
+    subnets,
+    subnetBits,
+    numSubnets,
+    hostsPerSubnet,
+    newPrefix,
+    subnetMask: `255.255.255.${subnetMaskLastOctet}`,
+    blockSize
+  };
+}
+
+function cleanupStep() {
+  if (broadcastGenerator) {
+    clearInterval(broadcastGenerator);
+    broadcastGenerator = null;
+  }
+
+  if (broadcastAnimator) {
+    clearInterval(broadcastAnimator);
+    broadcastAnimator = null;
+  }
+
+  if (chefTimer) {
+    clearTimeout(chefTimer);
+    chefTimer = null;
+  }
+
+  broadcastPackets = [];
+}
+
+function setStep(newStep) {
+  if (newStep < 0 || newStep >= steps.length) {
+    return;
+  }
+
+  cleanupStep();
+  state.step = newStep;
+  updateUI();
+}
+
+function updateNavigation() {
+  stepIndicator.textContent = `Trin ${state.step + 1} af ${steps.length}`;
+  prevBtn.disabled = state.step === 0;
+
+  if (state.step === steps.length - 1) {
+    nextBtn.textContent = '🔄 Genstart';
+  } else {
+    nextBtn.textContent = 'Næste →';
+  }
+}
+
+function renderProgress() {
+  const items = steps
+    .map((stepItem, index) => {
+      const isCurrent = index === state.step;
+      const isComplete = index < state.step;
+      const circleClasses = isCurrent
+        ? 'bg-indigo-600 text-white'
+        : isComplete
+          ? 'bg-green-500 text-white'
+          : 'bg-gray-300 text-gray-700';
+      const label = isComplete ? '✓' : index + 1;
+      const connectorClass = isComplete ? 'bg-green-500' : 'bg-gray-300';
+
+      return `
+        <li class="flex items-center gap-2">
+          <div class="w-8 h-8 rounded-full flex items-center justify-center font-semibold ${circleClasses}">${label}</div>
+          ${index < steps.length - 1
+            ? `<span class="block w-12 md:w-16 h-1 rounded ${connectorClass}"></span>`
+            : ''}
+        </li>
+      `;
+    })
+    .join('');
+
+  progressEl.innerHTML = `
+    <div class="bg-white rounded-xl shadow-lg p-4 overflow-x-auto">
+      <ol class="flex items-center justify-between min-w-[520px]">${items}</ol>
+      <div class="text-center mt-4">
+        <h2 class="text-lg font-bold text-gray-800">${steps[state.step].title}</h2>
+        <p class="text-sm text-gray-600 mt-1">${steps[state.step].description}</p>
+      </div>
+    </div>
+  `;
+}
+
+function createDeviceCards(devices, extraClasses = '') {
+  return devices
+    .map(
+      (device) => `
+        <div class="device-card ${extraClasses}">
+          <div class="text-xl">💻</div>
+          <span>${device.ip}</span>
+        </div>
+      `
+    )
+    .join('');
+}
+
+function renderStep0() {
+  const deviceGrid = createDeviceCards(originalDevices);
+
+  visualizationEl.innerHTML = `
+    <div class="relative min-h-[500px]">
+      <div class="border-4 border-red-400 rounded-xl p-4 md:p-6 bg-red-50 relative overflow-hidden min-h-[500px]">
+        <div class="callout-box absolute top-4 left-4 z-10">
+          <p class="font-bold text-gray-800">Netværk: 192.168.1.0/24</p>
+          <p class="text-gray-600">Subnet mask: 255.255.255.0</p>
+          <p class="text-gray-500">× 24 enheder</p>
+        </div>
+
+        <div class="absolute left-1/2 -translate-x-1/2 top-12 bg-gray-800 text-white rounded-lg border-4 border-gray-900 shadow-2xl px-10 py-3 z-20">
+          <div class="font-bold text-sm text-center mb-2 tracking-widest">LAN SWITCH</div>
+          <div class="flex gap-1 justify-center">
+            ${Array.from({ length: 12 })
+              .map(() => '<span class="block w-2 h-6 bg-green-400 rounded"></span>')
+              .join('')}
+          </div>
+        </div>
+
+        <svg id="broadcast-svg" class="absolute inset-0 w-full h-full" viewBox="0 0 100 100" preserveAspectRatio="none">
+          <g id="line-layer"></g>
+          <g id="packet-layer"></g>
+        </svg>
+
+        <div class="absolute w-full" style="top: 160px;" id="device-wrapper">
+          <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4 px-4">
+            ${deviceGrid}
+          </div>
+        </div>
+
+        <div class="absolute bottom-6 right-6 text-6xl">⚠️</div>
+      </div>
+
+      <div id="chef-popup" class="hidden absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white border-4 border-indigo-600 rounded-xl p-6 shadow-2xl max-w-sm z-30">
+        <div class="text-4xl mb-3 text-center">👨‍💼</div>
+        <p class="text-lg font-bold text-gray-800 mb-2">Netværksadministrator:</p>
+        <p class="text-sm text-gray-700">"Vi har et problem! Alt for meget broadcast-trafik gennem switchen. Vi skal opdele netværket i mindre subnets!"</p>
+      </div>
+    </div>
+  `;
+
+  setupBroadcastScene();
+}
+
+function renderSubnetColumn(index) {
+  const isFirst = index === 1;
+  const devices = isFirst ? subnet1Devices : subnet2Devices;
+  const collapsed = isFirst ? state.subnet1Collapsed : state.subnet2Collapsed;
+  const color = isFirst ? 'green' : 'blue';
+  const borderClass = isFirst ? 'border-green-500 bg-green-50' : 'border-blue-500 bg-blue-50';
+  const headerBorder = isFirst ? 'border-green-400' : 'border-blue-400';
+  const badgeColor = isFirst ? 'bg-green-200 text-green-700' : 'bg-blue-200 text-blue-700';
+  const wifiEmoji = '📶';
+  const networkTitle = isFirst ? 'Subnet 1: 192.168.1.0/25' : 'Subnet 2: 192.168.1.128/25';
+  const maskTitle = 'Mask: 255.255.255.128';
+
+  return `
+    <div class="border-4 ${borderClass} rounded-xl p-4 relative">
+      <button data-action="toggle-subnet" data-target="${index}" class="w-full flex items-center justify-between bg-white ${headerBorder} border-2 rounded-lg px-3 py-2 text-left shadow-sm">
+        <div>
+          <p class="font-bold text-gray-800 text-sm">${networkTitle}</p>
+          <p class="text-xs text-gray-600">${maskTitle}</p>
+          <p class="text-xs text-gray-500">× 12 enheder</p>
+        </div>
+        <span class="text-2xl text-${color}-600">${collapsed ? '▼' : '▲'}</span>
+      </button>
+
+      ${collapsed
+        ? ''
+        : `
+          <div class="mt-4">
+            <div class="bg-gray-800 text-white rounded-lg border-4 border-gray-900 shadow-xl px-4 py-2 mx-auto w-fit">
+              <p class="text-xs font-bold text-center mb-1">SWITCH ${index}</p>
+              <div class="flex gap-1 justify-center">
+                ${Array.from({ length: 6 })
+                  .map(() => '<span class="block w-2 h-5 bg-green-400 rounded"></span>')
+                  .join('')}
+              </div>
+            </div>
+
+            <div class="grid grid-cols-3 gap-2 mt-4">
+              ${createDeviceCards(devices, isFirst ? 'border-green-400' : 'border-blue-400')}
+            </div>
+
+            <div class="mt-3 text-center">
+              <span class="inline-flex items-center gap-1 ${badgeColor} px-3 py-1 rounded-full text-xs font-semibold">${wifiEmoji} Lokalt broadcast</span>
+            </div>
+          </div>
+        `}
+    </div>
+  `;
+}
+
+function renderStep1() {
+  visualizationEl.innerHTML = `
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 min-h-[500px]">
+      ${renderSubnetColumn(1)}
+      ${renderSubnetColumn(2)}
+    </div>
+  `;
+
+  visualizationEl.querySelectorAll('[data-action="toggle-subnet"]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const target = Number(button.getAttribute('data-target'));
+      if (target === 1) {
+        state.subnet1Collapsed = !state.subnet1Collapsed;
+      } else {
+        state.subnet2Collapsed = !state.subnet2Collapsed;
+      }
+      renderStep1();
+    });
+  });
+}
+
+function renderStep2() {
+  visualizationEl.innerHTML = `
+    <div class="space-y-6">
+      <div class="bg-indigo-50 border-2 border-indigo-400 rounded-xl p-6">
+        <h3 class="text-xl font-bold text-gray-800 mb-4">Sådan beregner vi den nye mask:</h3>
+        <div class="space-y-4">
+          <div class="bg-white p-4 rounded-lg border border-gray-200 shadow-sm">
+            <p class="font-bold text-gray-800 mb-2">Originalt netværk:</p>
+            <p class="text-gray-700">192.168.1.0/24</p>
+            <p class="text-gray-600 text-sm">Subnet mask: 255.255.255.0</p>
+            <p class="text-gray-600 text-sm">Binært: 11111111.11111111.11111111.<span class="text-red-500 font-semibold">00000000</span></p>
+          </div>
+          <div class="text-center text-2xl">↓</div>
+          <div class="bg-white p-4 rounded-lg border border-green-300 shadow-sm">
+            <p class="font-bold text-gray-800 mb-2">Ny subnet mask (vi låner 1 bit):</p>
+            <p class="text-gray-700">255.255.255.128 → /25</p>
+            <p class="text-gray-600 text-sm">Binært: 11111111.11111111.11111111.<span class="text-green-600 font-semibold">10000000</span></p>
+            <p class="text-indigo-600 font-bold text-sm mt-2">Dette giver os 2<sup>1</sup> = 2 subnets!</p>
+          </div>
+        </div>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="bg-green-100 border-2 border-green-500 rounded-xl p-4">
+          <h4 class="font-bold text-gray-800 mb-2">Subnet 1:</h4>
+          <ul class="text-sm text-gray-700 space-y-1">
+            <li><strong>Netværk:</strong> 192.168.1.0</li>
+            <li><strong>Første IP:</strong> 192.168.1.1</li>
+            <li><strong>Sidste IP:</strong> 192.168.1.126</li>
+            <li><strong>Broadcast:</strong> 192.168.1.127</li>
+            <li class="text-indigo-600 font-semibold">Range: 0 - 127</li>
+          </ul>
+        </div>
+        <div class="bg-blue-100 border-2 border-blue-500 rounded-xl p-4">
+          <h4 class="font-bold text-gray-800 mb-2">Subnet 2:</h4>
+          <ul class="text-sm text-gray-700 space-y-1">
+            <li><strong>Netværk:</strong> 192.168.1.128</li>
+            <li><strong>Første IP:</strong> 192.168.1.129</li>
+            <li><strong>Sidste IP:</strong> 192.168.1.254</li>
+            <li><strong>Broadcast:</strong> 192.168.1.255</li>
+            <li class="text-indigo-600 font-semibold">Range: 128 - 255</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function renderStep3() {
+  visualizationEl.innerHTML = `
+    <div class="space-y-4">
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div class="border-4 border-green-500 rounded-xl p-4 bg-green-50">
+          <div class="bg-white p-3 rounded-lg border border-green-400 shadow-sm mb-3">
+            <p class="font-bold text-sm text-gray-800">Subnet 1: 192.168.1.0/25</p>
+            <p class="text-xs text-gray-600">Mask: 255.255.255.128</p>
+            <p class="text-xs text-gray-500">Netværk: 192.168.1.0</p>
+            <p class="text-xs text-gray-500">Gateway: 192.168.1.1</p>
+            <p class="text-xs text-gray-500">Broadcast: 192.168.1.127</p>
+          </div>
+          <div class="grid grid-cols-3 gap-2">
+            ${createDeviceCards(subnet1Devices, 'border-green-400')}
+          </div>
+          <div class="mt-3 text-center">
+            <span class="badge">📶 Lokalt broadcast</span>
+          </div>
+        </div>
+        <div class="border-4 border-blue-500 rounded-xl p-4 bg-blue-50">
+          <div class="bg-white p-3 rounded-lg border border-blue-400 shadow-sm mb-3">
+            <p class="font-bold text-sm text-gray-800">Subnet 2: 192.168.1.128/25</p>
+            <p class="text-xs text-gray-600">Mask: 255.255.255.128</p>
+            <p class="text-xs text-gray-500">Netværk: 192.168.1.128</p>
+            <p class="text-xs text-gray-500">Gateway: 192.168.1.129</p>
+            <p class="text-xs text-gray-500">Broadcast: 192.168.1.255</p>
+          </div>
+          <div class="grid grid-cols-3 gap-2">
+            ${createDeviceCards(subnet2Devices, 'border-blue-400')}
+          </div>
+          <div class="mt-3 text-center">
+            <span class="badge" style="background-color:#bfdbfe;color:#1d4ed8;">📶 Lokalt broadcast</span>
+          </div>
+        </div>
+      </div>
+      <div class="bg-green-100 border-2 border-green-500 rounded-xl p-4">
+        <h3 class="text-lg font-bold text-gray-800 mb-2 flex items-center gap-2">✅ Resultatet:</h3>
+        <ul class="text-sm text-gray-700 space-y-1">
+          <li>• Broadcast-trafik er isoleret i hvert subnet.</li>
+          <li>• Hver enhed modtager kun relevante broadcasts.</li>
+          <li>• Reduceret netværksbelastning og bedre ydeevne.</li>
+          <li>• Nemmer fejlfinding og administration.</li>
+        </ul>
+      </div>
+    </div>
+  `;
+}
+
+function renderStep4() {
+  const calc = calculateSubnetting();
+
+  const subnetCards = calc.subnets
+    .map(
+      (subnet) => `
+        <div class="bg-white border-2 border-indigo-400 rounded-xl p-4 shadow-sm">
+          <div class="bg-indigo-600 text-white font-semibold text-center py-1 rounded-lg mb-3">Subnet ${subnet.id + 1}</div>
+          <div class="space-y-2 text-sm">
+            <div class="bg-blue-50 rounded p-2">
+              <p class="text-xs text-gray-600 font-semibold uppercase">Netværksadresse</p>
+              <p class="font-mono text-gray-800 font-bold">${subnet.network}/${calc.newPrefix}</p>
+            </div>
+            <div class="bg-green-50 rounded p-2">
+              <p class="text-xs text-gray-600 font-semibold uppercase">Første IP</p>
+              <p class="font-mono text-gray-800 font-bold">${subnet.firstHost}</p>
+            </div>
+            <div class="bg-green-50 rounded p-2">
+              <p class="text-xs text-gray-600 font-semibold uppercase">Sidste IP</p>
+              <p class="font-mono text-gray-800 font-bold">${subnet.lastHost}</p>
+            </div>
+            <div class="bg-red-50 rounded p-2">
+              <p class="text-xs text-gray-600 font-semibold uppercase">Broadcast</p>
+              <p class="font-mono text-gray-800 font-bold">${subnet.broadcast}</p>
+            </div>
+            <div class="bg-purple-50 rounded p-2 text-center border border-purple-200">
+              <p class="text-xs text-gray-600 uppercase">Brugbare hosts</p>
+              <p class="text-xl font-bold text-purple-600">${subnet.usableHosts}</p>
+            </div>
+          </div>
+        </div>
+      `
+    )
+    .join('');
+
+  visualizationEl.innerHTML = `
+    <div class="space-y-5">
+      <div class="bg-purple-50 border-2 border-purple-400 rounded-xl p-4">
+        <h3 class="text-lg font-bold text-gray-800 mb-3">🎮 Eksperimenter med subnetting</h3>
+        <div class="flex flex-col md:flex-row gap-3">
+          <button data-mode="subnets" class="flex-1 py-2 px-3 rounded-lg font-bold text-sm border ${state.calculationMode === 'subnets' ? 'bg-purple-600 text-white border-purple-600' : 'bg-white text-gray-700 border-gray-300'}">Vælg antal subnets</button>
+          <button data-mode="hosts" class="flex-1 py-2 px-3 rounded-lg font-bold text-sm border ${state.calculationMode === 'hosts' ? 'bg-purple-600 text-white border-purple-600' : 'bg-white text-gray-700 border-gray-300'}">Vælg antal hosts pr. subnet</button>
+        </div>
+        <div class="bg-white border border-purple-200 rounded-lg p-4 mt-3">
+          ${state.calculationMode === 'subnets'
+            ? `
+              <label class="block text-sm font-semibold text-gray-800 mb-2">Hvor mange subnets vil du have?</label>
+              <div class="flex items-center gap-4">
+                <input type="range" id="subnet-range" min="0" max="8" step="1" value="${Math.log2(state.customSubnets)}" class="flex-1" />
+                <span class="text-3xl font-bold text-purple-600 min-w-[3rem] text-center">${state.customSubnets}</span>
+              </div>
+              <p class="text-xs text-gray-500 mt-1">Værdien er en potens af to (2, 4, 8, ... 256).</p>
+            `
+            : `
+              <label class="block text-sm font-semibold text-gray-800 mb-2">Hvor mange hosts skal der være plads til pr. subnet?</label>
+              <div class="flex items-center gap-4">
+                <input type="range" id="hosts-range" min="2" max="254" value="${state.customHosts}" class="flex-1" />
+                <span class="text-3xl font-bold text-purple-600 min-w-[3rem] text-center">${state.customHosts}</span>
+              </div>
+            `}
+        </div>
+      </div>
+
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div class="bg-white border-2 border-indigo-400 rounded-xl p-3 text-center">
+          <p class="text-xs text-gray-500 uppercase">Antal subnets</p>
+          <p class="text-2xl font-bold text-indigo-600">${calc.numSubnets}</p>
+        </div>
+        <div class="bg-white border-2 border-indigo-400 rounded-xl p-3 text-center">
+          <p class="text-xs text-gray-500 uppercase">Hosts pr. subnet</p>
+          <p class="text-2xl font-bold text-indigo-600">${calc.hostsPerSubnet}</p>
+        </div>
+        <div class="bg-white border-2 border-indigo-400 rounded-xl p-3 text-center">
+          <p class="text-xs text-gray-500 uppercase">Subnet bits lånt</p>
+          <p class="text-2xl font-bold text-indigo-600">${calc.subnetBits}</p>
+        </div>
+        <div class="bg-white border-2 border-indigo-400 rounded-xl p-3 text-center">
+          <p class="text-xs text-gray-500 uppercase">Ny subnet mask</p>
+          <p class="text-lg font-bold text-indigo-600">${calc.subnetMask}</p>
+          <p class="text-xs text-gray-500">/${calc.newPrefix}</p>
+        </div>
+      </div>
+
+      <div class="bg-yellow-50 border-2 border-yellow-400 rounded-xl p-4 text-sm text-gray-700">
+        <p class="font-bold text-gray-800 mb-2">💡 Hvorfor disse tal?</p>
+        <ul class="list-disc list-inside space-y-1">
+          <li>Vi startede med /24 (8 bits til hosts).</li>
+          <li>Vi låner <strong>${calc.subnetBits}</strong> bit(s) til subnetting.</li>
+          <li>Det giver 2<sup>${calc.subnetBits}</sup> = <strong>${calc.numSubnets}</strong> subnets.</li>
+          <li>Der er ${8 - calc.subnetBits} bits tilbage til hosts.</li>
+          <li>Brugbare hosts: 2<sup>${8 - calc.subnetBits}</sup> − 2 = <strong>${calc.hostsPerSubnet}</strong>.</li>
+        </ul>
+      </div>
+
+      <div class="bg-gradient-to-br from-slate-100 to-slate-200 border-4 border-slate-300 rounded-xl p-4">
+        <div class="flex items-center justify-between mb-3">
+          <h4 class="text-lg font-bold text-gray-800">🌐 Netværk: 192.168.1.0/${calc.newPrefix}</h4>
+          <span class="bg-white border border-gray-300 rounded-lg px-3 py-1 text-sm font-semibold text-gray-700">${calc.numSubnets} subnets</span>
+        </div>
+        <div class="card-grid grid-scroll">
+          ${subnetCards}
+        </div>
+        ${calc.subnets.length >= 256
+          ? '<p class="text-xs text-gray-500 mt-2">Viser de første 256 subnets for at holde listen håndterbar.</p>'
+          : ''}
+      </div>
+    </div>
+  `;
+
+  visualizationEl.querySelectorAll('[data-mode]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const mode = button.getAttribute('data-mode');
+      state.calculationMode = mode;
+      if (mode === 'subnets' && (state.customSubnets & (state.customSubnets - 1)) !== 0) {
+        // Sikrer at værdien er en potens af to
+        state.customSubnets = 2;
+      }
+      renderStep4();
+    });
+  });
+
+  const subnetRange = document.getElementById('subnet-range');
+  if (subnetRange) {
+    subnetRange.addEventListener('input', (event) => {
+      const power = Number(event.target.value);
+      state.customSubnets = Math.pow(2, power);
+      renderStep4();
+    });
+  }
+
+  const hostsRange = document.getElementById('hosts-range');
+  if (hostsRange) {
+    hostsRange.addEventListener('input', (event) => {
+      state.customHosts = Number(event.target.value);
+      renderStep4();
+    });
+  }
+}
+
+function renderVisualization() {
+  visualizationEl.classList.remove('fade-in');
+  void visualizationEl.offsetWidth; // trigger reflow
+  visualizationEl.classList.add('fade-in');
+
+  calculatorEl.innerHTML = '';
+
+  switch (state.step) {
+    case 0:
+      renderStep0();
+      break;
+    case 1:
+      renderStep1();
+      break;
+    case 2:
+      renderStep2();
+      break;
+    case 3:
+      renderStep3();
+      break;
+    case 4:
+      renderStep4();
+      break;
+    default:
+      visualizationEl.innerHTML = '';
+  }
+}
+
+function setupBroadcastScene() {
+  const svg = document.getElementById('broadcast-svg');
+  if (!svg) {
+    return;
+  }
+
+  const lineLayer = svg.querySelector('#line-layer');
+  const packetLayer = svg.querySelector('#packet-layer');
+
+  lineLayer.innerHTML = '';
+  packetLayer.innerHTML = '';
+  broadcastPackets = [];
+
+  originalDevices.forEach((device, index) => {
+    const { x, y } = getDevicePosition(index);
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.setAttribute('x1', x);
+    line.setAttribute('y1', y);
+    line.setAttribute('x2', '50');
+    line.setAttribute('y2', '12');
+    line.setAttribute('stroke', '#9ca3af');
+    line.setAttribute('stroke-width', '1.8');
+    lineLayer.appendChild(line);
+  });
+
+  broadcastGenerator = setInterval(() => {
+    const fromIndex = Math.floor(Math.random() * originalDevices.length);
+    const startPos = getDevicePosition(fromIndex);
+
+    let targetIndex = Math.floor(Math.random() * originalDevices.length);
+    while (targetIndex === fromIndex) {
+      targetIndex = Math.floor(Math.random() * originalDevices.length);
+    }
+    const targetPos = getDevicePosition(targetIndex);
+
+    const packet = {
+      id: Date.now() + Math.random(),
+      from: fromIndex,
+      target: targetIndex,
+      progress: 0,
+      element: document.createElementNS('http://www.w3.org/2000/svg', 'circle'),
+      startPos,
+      targetPos
+    };
+
+    packet.element.setAttribute('r', '2.2');
+    packet.element.setAttribute('class', 'packet');
+    packet.element.setAttribute('cx', startPos.x);
+    packet.element.setAttribute('cy', startPos.y);
+    packetLayer.appendChild(packet.element);
+    broadcastPackets.push(packet);
+
+    if (broadcastPackets.length > 12) {
+      const removed = broadcastPackets.shift();
+      if (removed && removed.element && removed.element.parentNode) {
+        removed.element.parentNode.removeChild(removed.element);
+      }
+    }
+  }, 450);
+
+  broadcastAnimator = setInterval(() => {
+    broadcastPackets = broadcastPackets.filter((packet) => {
+      const nextProgress = packet.progress + 0.05;
+      packet.progress = nextProgress;
+
+      if (nextProgress > 2) {
+        if (packet.element.parentNode) {
+          packet.element.parentNode.removeChild(packet.element);
+        }
+        return false;
+      }
+
+      let x;
+      let y;
+
+      if (nextProgress <= 1) {
+        x = packet.startPos.x + (50 - packet.startPos.x) * nextProgress;
+        y = packet.startPos.y + (12 - packet.startPos.y) * nextProgress;
+      } else {
+        const t = nextProgress - 1;
+        x = 50 + (packet.targetPos.x - 50) * t;
+        y = 12 + (packet.targetPos.y - 12) * t;
+      }
+
+      packet.element.setAttribute('cx', x);
+      packet.element.setAttribute('cy', y);
+      packet.element.classList.add('active');
+      return true;
+    });
+  }, 50);
+
+  chefTimer = setTimeout(() => {
+    const popup = document.getElementById('chef-popup');
+    if (popup) {
+      popup.classList.remove('hidden');
+    }
+  }, 4000);
+}
+
+function updateUI() {
+  renderProgress();
+  renderVisualization();
+  updateNavigation();
+}
+
+prevBtn.addEventListener('click', () => {
+  setStep(state.step - 1);
+});
+
+nextBtn.addEventListener('click', () => {
+  if (state.step === steps.length - 1) {
+    state.step = 0;
+    state.subnet1Collapsed = false;
+    state.subnet2Collapsed = false;
+    state.calculationMode = 'subnets';
+    state.customSubnets = 2;
+    state.customHosts = 126;
+    updateUI();
+    return;
+  }
+  setStep(state.step + 1);
+});
+
+updateUI();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -136,3 +136,8 @@
   background: rgba(226, 232, 240, 0.8);
   box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.45);
 }
+
+.router-link-layer {
+  z-index: 25;
+  filter: drop-shadow(0 8px 16px rgba(15, 23, 42, 0.18));
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -512,3 +512,20 @@
   height: 100%;
   background: linear-gradient(90deg, #22c55e, #4ade80);
 }
+
+.site-footer {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  width: 100%;
+  background: linear-gradient(90deg, rgba(79, 70, 229, 0.08), rgba(14, 116, 144, 0.08));
+  border-top: 1px solid rgba(79, 70, 229, 0.2);
+  display: flex;
+  justify-content: center;
+}
+
+.site-footer__text {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #312e81;
+  letter-spacing: 0.02em;
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,111 @@
+:root {
+  color-scheme: light;
+}
+
+.btn,
+.btn-primary {
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.btn {
+  background-color: #6b7280;
+  color: #fff;
+}
+
+.btn:hover {
+  background-color: #4b5563;
+}
+
+.btn:disabled {
+  background-color: #d1d5db;
+  color: #6b7280;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background-color: #4f46e5;
+  color: #fff;
+}
+
+.btn-primary:hover {
+  background-color: #4338ca;
+}
+
+.device-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #fff;
+  border-radius: 0.75rem;
+  padding: 0.5rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.5);
+}
+
+.device-card span {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: #475569;
+  font-family: "Fira Code", Menlo, Monaco, Consolas, "Courier New", monospace;
+  text-align: center;
+}
+
+.callout-box {
+  background-color: #fef3c7;
+  border: 2px solid #facc15;
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  font-size: 0.75rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background-color: #bbf7d0;
+  color: #15803d;
+  padding: 0.35rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.grid-scroll {
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.fade-in {
+  animation: fadeIn 0.45s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.packet {
+  fill: #ef4444;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.packet.active {
+  opacity: 1;
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -141,3 +141,31 @@
   z-index: 25;
   filter: drop-shadow(0 8px 16px rgba(15, 23, 42, 0.18));
 }
+
+.router-packet {
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  filter: drop-shadow(0 0 4px rgba(14, 165, 233, 0.45));
+}
+
+.router-packet.active {
+  opacity: 1;
+}
+
+.router-burst {
+  fill: none;
+  opacity: 0.85;
+  animation: routerBurst 0.6s ease-out forwards;
+  mix-blend-mode: multiply;
+}
+
+@keyframes routerBurst {
+  from {
+    r: 0.6;
+    opacity: 0.85;
+  }
+  to {
+    r: 5.4;
+    opacity: 0;
+  }
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -529,3 +529,256 @@
   color: #312e81;
   letter-spacing: 0.02em;
 }
+
+.tutorial-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+@media (min-width: 1024px) {
+  .tutorial-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+    align-items: stretch;
+    gap: 2.5rem;
+  }
+}
+
+.tutorial-panel {
+  background: linear-gradient(145deg, rgba(224, 231, 255, 0.92), rgba(219, 234, 254, 0.96));
+  border: 2px solid rgba(99, 102, 241, 0.18);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: 0 25px 50px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.tutorial-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.tutorial-panel__kicker {
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4338ca;
+}
+
+.tutorial-panel__title {
+  font-size: 1.75rem;
+  font-weight: 800;
+  color: #1e1b4b;
+}
+
+.tutorial-panel p {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #1e293b;
+}
+
+.tutorial-section {
+  background: rgba(255, 255, 255, 0.86);
+  border-radius: 1.2rem;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.tutorial-section h3 {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #312e81;
+  margin-bottom: 0.6rem;
+}
+
+.tutorial-list {
+  list-style: disc;
+  padding-left: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: #1f2937;
+  font-size: 0.92rem;
+}
+
+.tutorial-steps {
+  counter-reset: tutorial-step;
+  display: grid;
+  gap: 0.7rem;
+  font-size: 0.92rem;
+  color: #1f2937;
+}
+
+.tutorial-steps li {
+  counter-increment: tutorial-step;
+  position: relative;
+  padding-left: 2.2rem;
+}
+
+.tutorial-steps li::before {
+  content: counter(tutorial-step);
+  position: absolute;
+  left: 0;
+  top: 0.1rem;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #6366f1, #7c3aed);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.85rem;
+  box-shadow: 0 8px 16px rgba(79, 70, 229, 0.25);
+}
+
+.tutorial-highlight {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.55rem;
+  border-radius: 9999px;
+  background: rgba(249, 250, 251, 0.85);
+  border: 1px solid rgba(79, 70, 229, 0.25);
+  font-weight: 600;
+  color: #4338ca;
+}
+
+.tutorial-panel__footer {
+  background: rgba(79, 70, 229, 0.08);
+  border-radius: 1rem;
+  padding: 1rem 1.25rem;
+  border: 1px dashed rgba(79, 70, 229, 0.35);
+}
+
+.term-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(79, 70, 229, 0.35);
+  background: rgba(199, 210, 254, 0.4);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #312e81;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+}
+
+.term-button:hover,
+.term-button:focus {
+  outline: none;
+  background: rgba(129, 140, 248, 0.35);
+  box-shadow: 0 12px 22px rgba(79, 70, 229, 0.18);
+  transform: translateY(-1px);
+}
+
+.term-button:active {
+  transform: translateY(0);
+}
+
+.tutorial-visual {
+  display: flex;
+  flex-direction: column;
+}
+
+.term-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.term-overlay.visible {
+  display: flex;
+}
+
+.term-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(4px);
+}
+
+.term-overlay__dialog {
+  position: relative;
+  width: min(620px, 92vw);
+  max-height: 80vh;
+  overflow-y: auto;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(226, 232, 240, 0.94));
+  border-radius: 1.25rem;
+  border: 1.5px solid rgba(99, 102, 241, 0.25);
+  box-shadow: 0 30px 60px rgba(30, 41, 59, 0.3);
+  padding: 1.75rem 2rem 2rem;
+}
+
+.term-overlay__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 9999px;
+  border: none;
+  background: rgba(148, 163, 184, 0.25);
+  color: #1f2937;
+  font-size: 1.4rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.term-overlay__close:hover,
+.term-overlay__close:focus {
+  outline: none;
+  background: rgba(99, 102, 241, 0.25);
+  transform: scale(1.05);
+}
+
+.term-overlay__title {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: #1e1b4b;
+  margin-bottom: 1rem;
+}
+
+.term-overlay__body {
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: #1f2937;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.term-overlay__body p {
+  margin: 0;
+}
+
+.term-overlay__loading {
+  color: #4338ca;
+  font-weight: 600;
+}
+
+.term-overlay__error {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.term-overlay__empty {
+  color: #475569;
+  font-style: italic;
+}
+
+body.term-overlay-open {
+  overflow: hidden;
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -118,8 +118,8 @@
   top: -18px;
   left: 50%;
   transform: translateX(-50%);
-  width: 3px;
-  height: 18px;
+  width: 5px;
+  height: 20px;
   border-radius: 9999px;
   background: linear-gradient(180deg, rgba(148, 163, 184, 0.25), rgba(100, 116, 139, 0.65));
 }
@@ -168,4 +168,296 @@
     r: 5.4;
     opacity: 0;
   }
+}
+
+.router-stop-marker circle {
+  fill: rgba(15, 23, 42, 0.9);
+  opacity: 0.85;
+}
+
+.router-stop-marker text {
+  fill: #f8fafc;
+  font-size: 3.1px;
+  text-anchor: middle;
+}
+
+.router-stop-banner {
+  position: absolute;
+  top: 120px;
+  max-width: 220px;
+  background: rgba(15, 118, 110, 0.92);
+  color: #ecfeff;
+  padding: 0.5rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  box-shadow: 0 10px 30px rgba(15, 118, 110, 0.2);
+  z-index: 45;
+  pointer-events: none;
+}
+
+.router-stop-banner span {
+  display: block;
+  text-align: center;
+}
+
+.router-stop-banner.left {
+  left: 8%;
+}
+
+.router-stop-banner.right {
+  right: 8%;
+  background: rgba(37, 99, 235, 0.92);
+}
+
+.router-gate-note {
+  position: absolute;
+  top: 140px;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 0.75rem;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #334155;
+  box-shadow: 0 8px 16px rgba(51, 65, 85, 0.12);
+  z-index: 35;
+  pointer-events: none;
+}
+
+.router-gate-note span {
+  display: block;
+  text-align: center;
+}
+
+.router-gate-note.left {
+  left: 12%;
+}
+
+.router-gate-note.right {
+  right: 12%;
+}
+
+.network-class-btn {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.85rem;
+  border: 2px solid rgba(148, 163, 184, 0.45);
+  background: rgba(255, 255, 255, 0.9);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1f2937;
+  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.network-class-btn span {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: #475569;
+}
+
+.network-class-btn:hover {
+  border-color: #6366f1;
+  box-shadow: 0 8px 18px rgba(99, 102, 241, 0.15);
+  transform: translateY(-1px);
+}
+
+.network-class-btn.active {
+  border-color: #4f46e5;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.18), rgba(79, 70, 229, 0.22));
+  color: #312e81;
+}
+
+.loading-spinner {
+  width: 2.75rem;
+  height: 2.75rem;
+  border: 4px solid rgba(99, 102, 241, 0.25);
+  border-top-color: #4f46e5;
+  border-radius: 9999px;
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.task-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.task-card {
+  background: #ffffff;
+  border: 2px solid rgba(99, 102, 241, 0.22);
+  border-radius: 1rem;
+  box-shadow: 0 18px 28px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+}
+
+.task-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 36px rgba(15, 23, 42, 0.12);
+}
+
+.task-card.correct {
+  border-color: #22c55e;
+  box-shadow: 0 20px 32px rgba(34, 197, 94, 0.18);
+}
+
+.task-card.incorrect {
+  border-color: #f97316;
+}
+
+.task-card.error {
+  border-color: #ef4444;
+}
+
+.task-card.checking {
+  border-color: #6366f1;
+}
+
+.task-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.1rem 0.75rem;
+  gap: 0.5rem;
+}
+
+.task-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.task-tag {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(99, 102, 241, 0.12);
+  color: #3730a3;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.2rem 0.55rem;
+  border-radius: 9999px;
+  margin-top: 0.35rem;
+}
+
+.task-status {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #475569;
+  text-align: right;
+}
+
+.task-body {
+  padding: 0 1.1rem;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.task-prompt {
+  font-size: 0.85rem;
+  color: #334155;
+  line-height: 1.45;
+}
+
+.task-answer {
+  width: 100%;
+  border-radius: 0.75rem;
+  border: 1.5px solid rgba(148, 163, 184, 0.6);
+  padding: 0.65rem 0.75rem;
+  font-size: 0.85rem;
+  resize: vertical;
+  min-height: 90px;
+  font-family: "Fira Code", Menlo, Consolas, "Courier New", monospace;
+  color: #1f2937;
+}
+
+.task-answer:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+
+.task-answer:disabled {
+  background: rgba(241, 245, 249, 0.7);
+  cursor: wait;
+}
+
+.task-footer {
+  padding: 0.75rem 1.1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.task-footer .btn-primary {
+  align-self: flex-start;
+}
+
+.task-feedback {
+  font-size: 0.8rem;
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.7rem;
+  line-height: 1.35;
+}
+
+.task-feedback.correct {
+  background: rgba(34, 197, 94, 0.12);
+  color: #166534;
+}
+
+.task-feedback.incorrect {
+  background: rgba(249, 115, 22, 0.12);
+  color: #9a3412;
+}
+
+.task-feedback.error {
+  background: rgba(239, 68, 68, 0.12);
+  color: #991b1b;
+}
+
+.task-feedback.checking {
+  background: rgba(99, 102, 241, 0.12);
+  color: #312e81;
+}
+
+.task-feedback.incomplete {
+  background: rgba(251, 191, 36, 0.14);
+  color: #92400e;
+}
+
+.task-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 160px;
+}
+
+.task-progress-count {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.task-progress-bar {
+  width: 100%;
+  height: 0.45rem;
+  background: rgba(148, 163, 184, 0.35);
+  border-radius: 9999px;
+  overflow: hidden;
+}
+
+.task-progress-bar > div {
+  height: 100%;
+  background: linear-gradient(90deg, #22c55e, #4ade80);
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -180,17 +180,15 @@
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
-.router-stop-icon {
+.router-stop-dot {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 1.6rem;
   height: 1.6rem;
   border-radius: 9999px;
-  background: #b91c1c;
-  color: #fef2f2;
-  font-size: 0.95rem;
-  box-shadow: inset 0 0 0 2px rgba(254, 242, 242, 0.6);
+  background: radial-gradient(circle at 30% 30%, #fecaca, #ef4444 65%, #991b1b);
+  box-shadow: 0 0 0 2px rgba(254, 226, 226, 0.6) inset, 0 0 12px rgba(239, 68, 68, 0.5);
 }
 
 .router-stop-label--active {
@@ -245,15 +243,15 @@
   }
 }
 
-.router-stop-marker circle {
-  fill: rgba(15, 23, 42, 0.9);
-  opacity: 0.85;
+.router-stop-marker__outer {
+  fill: rgba(15, 23, 42, 0.92);
+  opacity: 0.88;
 }
 
-.router-stop-marker text {
-  fill: #f8fafc;
-  font-size: 3.1px;
-  text-anchor: middle;
+.router-stop-marker__inner {
+  fill: #ef4444;
+  opacity: 0.95;
+  filter: drop-shadow(0 0 2px rgba(248, 113, 113, 0.7));
 }
 
 /* Tidligere router-banner og note-klasser er fjernet til fordel for central stop-indikator */

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -530,19 +530,10 @@
   letter-spacing: 0.02em;
 }
 
-.tutorial-grid {
+.step0-stack {
   display: flex;
   flex-direction: column;
   gap: 2.5rem;
-}
-
-@media (min-width: 1024px) {
-  .tutorial-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
-    align-items: stretch;
-    gap: 2.5rem;
-  }
 }
 
 .tutorial-panel {
@@ -554,6 +545,11 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.tutorial-panel--stacked {
+  max-height: 560px;
+  padding-bottom: 1.5rem;
 }
 
 .tutorial-panel__header {
@@ -595,6 +591,38 @@
   font-weight: 700;
   color: #312e81;
   margin-bottom: 0.6rem;
+}
+
+.tutorial-scroll {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-right: 0.75rem;
+  margin-top: 0.5rem;
+  max-height: 360px;
+}
+
+@media (min-width: 1024px) {
+  .tutorial-scroll {
+    max-height: 420px;
+  }
+}
+
+.tutorial-scroll::-webkit-scrollbar {
+  width: 8px;
+}
+
+.tutorial-scroll::-webkit-scrollbar-track {
+  background: rgba(226, 232, 240, 0.7);
+  border-radius: 999px;
+}
+
+.tutorial-scroll::-webkit-scrollbar-thumb {
+  background: rgba(79, 70, 229, 0.4);
+  border-radius: 999px;
+}
+
+.tutorial-scroll:hover::-webkit-scrollbar-thumb {
+  background: rgba(79, 70, 229, 0.55);
 }
 
 .tutorial-list {
@@ -655,6 +683,18 @@
   border-radius: 1rem;
   padding: 1rem 1.25rem;
   border: 1px dashed rgba(79, 70, 229, 0.35);
+}
+
+.tutorial-callout {
+  background: linear-gradient(135deg, rgba(254, 240, 138, 0.82), rgba(253, 224, 71, 0.82));
+  border-radius: 1.1rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(202, 138, 4, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.94rem;
+  color: #78350f;
 }
 
 .term-button {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -547,9 +547,78 @@
   gap: 1.5rem;
 }
 
-.tutorial-panel--stacked {
-  max-height: 560px;
-  padding-bottom: 1.5rem;
+.tutorial-panel--split {
+  gap: 2.5rem;
+}
+
+.tutorial-intro,
+.tutorial-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.tutorial-intro__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.tutorial-intro__objectives {
+  display: grid;
+  gap: 0.75rem;
+  padding-left: 1.2rem;
+  list-style: disc;
+  color: #1f2937;
+  font-size: 0.92rem;
+}
+
+.tutorial-intro__tips {
+  background: rgba(255, 255, 255, 0.86);
+  border-radius: 1.2rem;
+  border: 1px solid rgba(129, 140, 248, 0.35);
+  padding: 1.1rem 1.3rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+}
+
+.tutorial-intro__heading {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #312e81;
+  margin-bottom: 0.7rem;
+}
+
+.tutorial-intro__tips ol {
+  display: grid;
+  gap: 0.55rem;
+  padding-left: 1.4rem;
+  color: #1f2937;
+  font-size: 0.92rem;
+}
+
+.tutorial-body__lead p {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #1e293b;
+}
+
+.tutorial-panel--split .tutorial-panel__footer {
+  margin-top: auto;
+}
+
+@media (min-width: 1024px) {
+  .tutorial-panel--split {
+    flex-direction: row;
+  }
+
+  .tutorial-intro {
+    flex: 0 0 25%;
+    max-width: 320px;
+  }
+
+  .tutorial-body {
+    flex: 1 1 0%;
+  }
 }
 
 .tutorial-panel__header {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -139,7 +139,82 @@
 
 .router-link-layer {
   z-index: 25;
-  filter: drop-shadow(0 8px 16px rgba(15, 23, 42, 0.18));
+  filter: drop-shadow(0 10px 18px rgba(15, 23, 42, 0.16));
+  pointer-events: none;
+}
+
+.router-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.router-bridge-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #1e293b;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  box-shadow: 0 10px 25px rgba(148, 163, 184, 0.25);
+  letter-spacing: 0.04em;
+}
+
+.router-stop-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 1rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #b91c1c;
+  border-radius: 9999px;
+  background: linear-gradient(120deg, rgba(254, 226, 226, 0.95), rgba(254, 202, 202, 0.95));
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  box-shadow: 0 16px 30px rgba(239, 68, 68, 0.2);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.router-stop-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 9999px;
+  background: #b91c1c;
+  color: #fef2f2;
+  font-size: 0.95rem;
+  box-shadow: inset 0 0 0 2px rgba(254, 242, 242, 0.6);
+}
+
+.router-stop-label--active {
+  box-shadow: 0 20px 40px rgba(239, 68, 68, 0.28);
+  transform: translateY(-2px);
+}
+
+.router-stop-label--pulse {
+  animation: routerStopPulse 0.7s ease-out;
+}
+
+@keyframes routerStopPulse {
+  0% {
+    transform: translateY(-2px) scale(0.98);
+    box-shadow: 0 12px 24px rgba(239, 68, 68, 0.22);
+  }
+  50% {
+    transform: translateY(-4px) scale(1.04);
+    box-shadow: 0 28px 45px rgba(239, 68, 68, 0.35);
+  }
+  100% {
+    transform: translateY(-2px) scale(1);
+    box-shadow: 0 20px 40px rgba(239, 68, 68, 0.28);
+  }
 }
 
 .router-packet {
@@ -181,61 +256,7 @@
   text-anchor: middle;
 }
 
-.router-stop-banner {
-  position: absolute;
-  top: 120px;
-  max-width: 220px;
-  background: rgba(15, 118, 110, 0.92);
-  color: #ecfeff;
-  padding: 0.5rem 0.75rem;
-  border-radius: 9999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  box-shadow: 0 10px 30px rgba(15, 118, 110, 0.2);
-  z-index: 45;
-  pointer-events: none;
-}
-
-.router-stop-banner span {
-  display: block;
-  text-align: center;
-}
-
-.router-stop-banner.left {
-  left: 8%;
-}
-
-.router-stop-banner.right {
-  right: 8%;
-  background: rgba(37, 99, 235, 0.92);
-}
-
-.router-gate-note {
-  position: absolute;
-  top: 140px;
-  background: rgba(255, 255, 255, 0.92);
-  border-radius: 0.75rem;
-  padding: 0.35rem 0.75rem;
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: #334155;
-  box-shadow: 0 8px 16px rgba(51, 65, 85, 0.12);
-  z-index: 35;
-  pointer-events: none;
-}
-
-.router-gate-note span {
-  display: block;
-  text-align: center;
-}
-
-.router-gate-note.left {
-  left: 12%;
-}
-
-.router-gate-note.right {
-  right: 12%;
-}
+/* Tidligere router-banner og note-klasser er fjernet til fordel for central stop-indikator */
 
 .network-class-btn {
   display: inline-flex;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -551,11 +551,20 @@
   gap: 2.5rem;
 }
 
-.tutorial-intro,
-.tutorial-body {
+.tutorial-intro {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+}
+
+.tutorial-body {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 1.25rem;
+  min-height: 0;
+  align-content: stretch;
+  flex: 1 1 auto;
+  height: 100%;
 }
 
 .tutorial-intro__content {
@@ -603,7 +612,7 @@
 }
 
 .tutorial-panel--split .tutorial-panel__footer {
-  margin-top: auto;
+  margin-top: 0;
 }
 
 @media (min-width: 1024px) {
@@ -618,6 +627,7 @@
 
   .tutorial-body {
     flex: 1 1 0%;
+    min-height: 0;
   }
 }
 
@@ -667,10 +677,11 @@
   overflow-y: auto;
   padding-right: 0.75rem;
   margin-top: 0.5rem;
-  max-height: 360px;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  min-height: 0;
+  height: 100%;
 }
 
 .tutorial-scroll > * {
@@ -679,7 +690,7 @@
 
 @media (min-width: 1024px) {
   .tutorial-scroll {
-    max-height: 420px;
+    height: 100%;
   }
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -44,6 +44,8 @@
   padding: 0.5rem;
   box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
   border: 1px solid rgba(148, 163, 184, 0.5);
+  position: relative;
+  overflow: visible;
 }
 
 .device-card span {
@@ -108,4 +110,29 @@
 
 .packet.active {
   opacity: 1;
+}
+
+.device-card::after {
+  content: "";
+  position: absolute;
+  top: -18px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 3px;
+  height: 18px;
+  border-radius: 9999px;
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.25), rgba(100, 116, 139, 0.65));
+}
+
+.device-card::before {
+  content: "";
+  position: absolute;
+  top: -22px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 12px;
+  height: 6px;
+  border-radius: 9999px;
+  background: rgba(226, 232, 240, 0.8);
+  box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.45);
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -35,6 +35,29 @@
   background-color: #4338ca;
 }
 
+.btn-secondary {
+  padding: 0.5rem 1rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+  background-color: #fff;
+  color: #4338ca;
+  border: 1.5px solid rgba(79, 70, 229, 0.4);
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.btn-secondary:hover {
+  background-color: rgba(199, 210, 254, 0.35);
+  border-color: rgba(79, 70, 229, 0.6);
+}
+
+.btn-secondary:disabled {
+  background-color: rgba(226, 232, 240, 0.4);
+  color: rgba(71, 85, 105, 0.8);
+  border-color: rgba(148, 163, 184, 0.5);
+  cursor: not-allowed;
+}
+
 .device-card {
   display: flex;
   flex-direction: column;
@@ -243,19 +266,6 @@
   }
 }
 
-.router-stop-marker__outer {
-  fill: rgba(15, 23, 42, 0.92);
-  opacity: 0.88;
-}
-
-.router-stop-marker__inner {
-  fill: #ef4444;
-  opacity: 0.95;
-  filter: drop-shadow(0 0 2px rgba(248, 113, 113, 0.7));
-}
-
-/* Tidligere router-banner og note-klasser er fjernet til fordel for central stop-indikator */
-
 .network-class-btn {
   display: inline-flex;
   flex-direction: column;
@@ -419,8 +429,30 @@
   gap: 0.5rem;
 }
 
+.task-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
 .task-footer .btn-primary {
   align-self: flex-start;
+}
+
+.task-explanation {
+  background: rgba(99, 102, 241, 0.08);
+  border: 1.5px solid rgba(99, 102, 241, 0.25);
+  border-radius: 0.85rem;
+  padding: 0.75rem 0.85rem;
+  font-size: 0.82rem;
+  color: #312e81;
+  line-height: 1.45;
+}
+
+.task-explanation-answer {
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+  color: #1e293b;
 }
 
 .task-feedback {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -668,6 +668,13 @@
   padding-right: 0.75rem;
   margin-top: 0.5rem;
   max-height: 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.tutorial-scroll > * {
+  width: 100%;
 }
 
 @media (min-width: 1024px) {

--- a/data/subnet_tasks.json
+++ b/data/subnet_tasks.json
@@ -1,0 +1,212 @@
+[
+  {
+    "id": 1,
+    "category": "Hosts",
+    "prompt": "Hvor mange brugbare værtsadresser findes i subnettet 192.168.10.0/26?",
+    "expectedAnswer": "62",
+    "explanation": "Et /26 subnet har 64 adresser totalt. Fratræk 2 til netværks- og broadcast-adressen: 64 - 2 = 62." 
+  },
+  {
+    "id": 2,
+    "category": "Broadcast",
+    "prompt": "Angiv broadcast-adressen for subnettet 192.168.10.64/27.",
+    "expectedAnswer": "192.168.10.95",
+    "explanation": "Et /27 subnet har blokstørrelse 32. 64 + 31 = 95 er broadcast." 
+  },
+  {
+    "id": 3,
+    "category": "Maske",
+    "prompt": "Hvad er subnetmasken i decimalnotation for prefix /28?",
+    "expectedAnswer": "255.255.255.240",
+    "explanation": "Et /28 låner 4 bits i sidste oktet, hvilket giver masken 240." 
+  },
+  {
+    "id": 4,
+    "category": "Design",
+    "prompt": "Hvor mange subnets får du, når du låner 3 bits fra et /24 netværk?",
+    "expectedAnswer": "8",
+    "explanation": "3 lånte bits giver 2^3 = 8 subnets." 
+  },
+  {
+    "id": 5,
+    "category": "Adresser",
+    "prompt": "Hvad er den første brugbare adresse i 10.0.4.0/22?",
+    "expectedAnswer": "10.0.4.1",
+    "explanation": "Netværksadressen er 10.0.4.0, så første host er +1." 
+  },
+  {
+    "id": 6,
+    "category": "Adresser",
+    "prompt": "Hvad er den sidste brugbare adresse i 172.16.32.0/20?",
+    "expectedAnswer": "172.16.47.254",
+    "explanation": "Et /20 dækker adresserne 172.16.32.0-172.16.47.255, så sidste host er 172.16.47.254." 
+  },
+  {
+    "id": 7,
+    "category": "Design",
+    "prompt": "Hvilket prefix skal bruges for mindst 30 brugbare hosts i hvert subnet?",
+    "expectedAnswer": "/27",
+    "explanation": "Et /27 giver 32 adresser og 30 brugbare værter." 
+  },
+  {
+    "id": 8,
+    "category": "Hosts",
+    "prompt": "Hvor mange brugbare værter findes i netværket 10.20.0.0/19?",
+    "expectedAnswer": "8190",
+    "explanation": "Et /19 har 13 værtsbits: 2^13 - 2 = 8190." 
+  },
+  {
+    "id": 9,
+    "category": "Maske",
+    "prompt": "Hvad er subnetmasken i decimal for prefix /23?",
+    "expectedAnswer": "255.255.254.0",
+    "explanation": "Et /23 betyder at tredje oktet har 11111110 = 254." 
+  },
+  {
+    "id": 10,
+    "category": "Netværk",
+    "prompt": "Hvad er netværksadressen for IP'en 192.168.33.77/26?",
+    "expectedAnswer": "192.168.33.64",
+    "explanation": "Et /26 har blokstørrelse 64. 77 ligger i intervallet 64-127." 
+  },
+  {
+    "id": 11,
+    "category": "Broadcast",
+    "prompt": "Hvad er broadcast-adressen for IP'en 172.16.5.129/25?",
+    "expectedAnswer": "172.16.5.255",
+    "explanation": "Et /25 har blokstørrelse 128, så intervallet 172.16.5.128-255 ender på 255." 
+  },
+  {
+    "id": 12,
+    "category": "Design",
+    "prompt": "Hvor mange subnets kan du få ved at låne 5 bits fra et /16 netværk?",
+    "expectedAnswer": "32",
+    "explanation": "5 lånte bits giver 2^5 = 32 subnets." 
+  },
+  {
+    "id": 13,
+    "category": "Hosts",
+    "prompt": "Hvor mange brugbare værter findes der i et /30 subnet?",
+    "expectedAnswer": "2",
+    "explanation": "Et /30 har 4 adresser totalt, hvilket giver 2 brugbare værter." 
+  },
+  {
+    "id": 14,
+    "category": "Blokstørrelse",
+    "prompt": "Hvad er blokstørrelsen (antal adresser) for et /29 subnet?",
+    "expectedAnswer": "8",
+    "explanation": "Et /29 har 3 værtsbits, så 2^3 = 8 adresser i alt." 
+  },
+  {
+    "id": 15,
+    "category": "Adresser",
+    "prompt": "Hvad er første brugbare adresse i 192.168.200.128/26?",
+    "expectedAnswer": "192.168.200.129",
+    "explanation": "Netværksadressen er 192.168.200.128, så første host er +1." 
+  },
+  {
+    "id": 16,
+    "category": "Broadcast",
+    "prompt": "Hvad er broadcast-adressen for subnettet 10.10.128.0/17?",
+    "expectedAnswer": "10.10.255.255",
+    "explanation": "Et /17 dækker 10.10.128.0-10.10.255.255." 
+  },
+  {
+    "id": 17,
+    "category": "Netværk",
+    "prompt": "Hvad er netværksadressen for IP'en 10.33.19.201/20?",
+    "expectedAnswer": "10.33.16.0",
+    "explanation": "Et /20 har blokstørrelse 16 i tredje oktet. 19 falder i blokken der starter ved 16." 
+  },
+  {
+    "id": 18,
+    "category": "Design",
+    "prompt": "Hvilket prefix skal vælges for mindst 400 brugbare hosts pr. subnet?",
+    "expectedAnswer": "/23",
+    "explanation": "Et /23 giver 512 adresser og 510 brugbare værter, hvilket opfylder kravet." 
+  },
+  {
+    "id": 19,
+    "category": "Hosts",
+    "prompt": "Hvor mange brugbare værter er der i 172.16.0.0/21?",
+    "expectedAnswer": "2046",
+    "explanation": "Et /21 har 11 værtsbits: 2^11 - 2 = 2046." 
+  },
+  {
+    "id": 20,
+    "category": "Maske",
+    "prompt": "Hvad er subnetmasken i decimal for prefix /22?",
+    "expectedAnswer": "255.255.252.0",
+    "explanation": "Et /22 giver 11111100 i tredje oktet = 252." 
+  },
+  {
+    "id": 21,
+    "category": "Broadcast",
+    "prompt": "Hvad er broadcast-adressen for 192.168.14.192/26?",
+    "expectedAnswer": "192.168.14.255",
+    "explanation": "Et /26 har blokstørrelse 64. Blokken 192-255 slutter på 255." 
+  },
+  {
+    "id": 22,
+    "category": "Netværk",
+    "prompt": "Hvad er netværksadressen for IP'en 172.16.99.200/18?",
+    "expectedAnswer": "172.16.64.0",
+    "explanation": "Et /18 har blokstørrelse 64 i tredje oktet. 99 ligger i blokken der starter ved 64." 
+  },
+  {
+    "id": 23,
+    "category": "Design",
+    "prompt": "Hvor mange subnets fås ved at låne 2 bits fra et /20 netværk?",
+    "expectedAnswer": "4",
+    "explanation": "2 lånte bits giver 2^2 = 4 subnets." 
+  },
+  {
+    "id": 24,
+    "category": "Hosts",
+    "prompt": "Hvor mange brugbare værter er der i et /27 subnet?",
+    "expectedAnswer": "30",
+    "explanation": "Et /27 har 32 adresser totalt og dermed 30 brugbare." 
+  },
+  {
+    "id": 25,
+    "category": "Adresser",
+    "prompt": "Hvad er den første brugbare adresse i 10.0.64.0/18?",
+    "expectedAnswer": "10.0.64.1",
+    "explanation": "Netværksadressen er 10.0.64.0, så første host er +1." 
+  },
+  {
+    "id": 26,
+    "category": "Broadcast",
+    "prompt": "Hvad er broadcast-adressen for subnettet 172.16.48.0/20?",
+    "expectedAnswer": "172.16.63.255",
+    "explanation": "Et /20 dækker 172.16.48.0-172.16.63.255." 
+  },
+  {
+    "id": 27,
+    "category": "Maske",
+    "prompt": "Hvad er subnetmasken i decimal for prefix /30?",
+    "expectedAnswer": "255.255.255.252",
+    "explanation": "Et /30 efterlader 2 værtsbits i sidste oktet: 11111100 = 252." 
+  },
+  {
+    "id": 28,
+    "category": "Netværk",
+    "prompt": "Hvad er netværksadressen for IP'en 192.168.19.5/28?",
+    "expectedAnswer": "192.168.19.0",
+    "explanation": "Et /28 har blokstørrelse 16. 5 ligger i blokken 0-15." 
+  },
+  {
+    "id": 29,
+    "category": "Design",
+    "prompt": "Hvilket prefix giver mindst 12 brugbare hosts i hvert subnet?",
+    "expectedAnswer": "/28",
+    "explanation": "Et /28 giver 16 adresser og 14 brugbare værter, som opfylder kravet." 
+  },
+  {
+    "id": 30,
+    "category": "Hosts",
+    "prompt": "Hvor mange brugbare værter findes i netværket 10.0.0.0/18?",
+    "expectedAnswer": "16382",
+    "explanation": "Et /18 har 14 værtsbits: 2^14 - 2 = 16382." 
+  }
+]

--- a/data/subnet_tasks.json
+++ b/data/subnet_tasks.json
@@ -207,6 +207,146 @@
     "category": "Hosts",
     "prompt": "Hvor mange brugbare værter findes i netværket 10.0.0.0/18?",
     "expectedAnswer": "16382",
-    "explanation": "Et /18 har 14 værtsbits: 2^14 - 2 = 16382." 
+    "explanation": "Et /18 har 14 værtsbits: 2^14 - 2 = 16382."
+  },
+  {
+    "id": 31,
+    "category": "Design",
+    "prompt": "Hvilket prefix skal du vælge for et subnet med mindst 900 brugbare værter?",
+    "expectedAnswer": "/22",
+    "explanation": "Et subnet med mindst 900 brugbare værter kræver 10 værtsbits: 2^10 - 2 = 1022. 32 - 10 = 22, så prefixet skal være /22."
+  },
+  {
+    "id": 32,
+    "category": "Netværk",
+    "prompt": "Hvad er netværksadressen for IP'en 10.12.45.200/21?",
+    "expectedAnswer": "10.12.40.0",
+    "explanation": "Et /21 har blokstørrelse 8 i tredje oktet (masken 255.255.248.0). 45 ligger i blokken, der starter ved 40."
+  },
+  {
+    "id": 33,
+    "category": "Broadcast",
+    "prompt": "Hvad er broadcast-adressen for subnettet 172.20.192.0/20?",
+    "expectedAnswer": "172.20.207.255",
+    "explanation": "Et /20 har blokstørrelse 16 i tredje oktet. Intervallet 192-207 afsluttes med broadcast-adressen 172.20.207.255."
+  },
+  {
+    "id": 34,
+    "category": "Maske",
+    "prompt": "Hvad er subnetmasken i decimal for prefix /17?",
+    "expectedAnswer": "255.255.128.0",
+    "explanation": "Et /17 betyder 1 værtsbit i tredje oktet: 10000000 i binær svarer til 128 i decimal."
+  },
+  {
+    "id": 35,
+    "category": "Design",
+    "prompt": "Hvor mange subnets får du ved at opdele et /24 netværk til /28?",
+    "expectedAnswer": "16",
+    "explanation": "Fra /24 til /28 låner du 4 bits. 2^4 = 16 subnets."
+  },
+  {
+    "id": 36,
+    "category": "Hosts",
+    "prompt": "Hvor mange brugbare værter findes i netværket 192.168.16.0/23?",
+    "expectedAnswer": "510",
+    "explanation": "Et /23 har 9 værtsbits: 2^9 - 2 = 510 brugbare værter."
+  },
+  {
+    "id": 37,
+    "category": "Adresser",
+    "prompt": "Hvad er den første brugbare adresse i 172.31.64.0/19?",
+    "expectedAnswer": "172.31.64.1",
+    "explanation": "Netværksadressen er 172.31.64.0, så første host er +1."
+  },
+  {
+    "id": 38,
+    "category": "Broadcast",
+    "prompt": "Hvad er broadcast-adressen for IP'en 192.168.5.190/26?",
+    "expectedAnswer": "192.168.5.191",
+    "explanation": "Et /26 har blokstørrelse 64. IP'en ligger i blokken 128-191, så broadcast-adressen er 192.168.5.191."
+  },
+  {
+    "id": 39,
+    "category": "Hosts",
+    "prompt": "Hvor mange brugbare værter er der i hvert subnet med prefix /25?",
+    "expectedAnswer": "126",
+    "explanation": "Et /25 har 7 værtsbits: 2^7 - 2 = 126 brugbare adresser."
+  },
+  {
+    "id": 40,
+    "category": "Design",
+    "prompt": "Hvilket prefix giver plads til mindst 50 brugbare værter i hvert subnet?",
+    "expectedAnswer": "/26",
+    "explanation": "Et /26 har 6 værtsbits: 2^6 - 2 = 62 brugbare værter, hvilket opfylder kravet på 50."
+  },
+  {
+    "id": 41,
+    "category": "Netværk",
+    "prompt": "Hvad er netværksadressen for IP'en 203.0.113.78/29?",
+    "expectedAnswer": "203.0.113.72",
+    "explanation": "Et /29 har blokstørrelse 8. 78 ligger i blokken 72-79, så netværksadressen er 203.0.113.72."
+  },
+  {
+    "id": 42,
+    "category": "Adresser",
+    "prompt": "Hvad er den sidste brugbare adresse i 198.51.100.128/27?",
+    "expectedAnswer": "198.51.100.158",
+    "explanation": "Et /27 dækker 128-159. Broadcast er 198.51.100.159, så sidste host er 198.51.100.158."
+  },
+  {
+    "id": 43,
+    "category": "Hosts",
+    "prompt": "Hvor mange brugbare værter findes i et /22 subnet?",
+    "expectedAnswer": "1022",
+    "explanation": "Et /22 har 10 værtsbits: 2^10 - 2 = 1022 brugbare værter."
+  },
+  {
+    "id": 44,
+    "category": "Broadcast",
+    "prompt": "Hvad er broadcast-adressen for subnettet 10.50.12.0/23?",
+    "expectedAnswer": "10.50.13.255",
+    "explanation": "Et /23 dækker to sammenhængende /24-net: 10.50.12.0-10.50.13.255, så broadcast er 10.50.13.255."
+  },
+  {
+    "id": 45,
+    "category": "Design",
+    "prompt": "Hvilket prefix skal vælges for mindst 2000 brugbare værter i et subnet?",
+    "expectedAnswer": "/21",
+    "explanation": "2000 værter kræver 11 værtsbits: 2^11 - 2 = 2046. 32 - 11 = 21, så prefixet skal være /21."
+  },
+  {
+    "id": 46,
+    "category": "Design",
+    "prompt": "Hvor mange subnets får du ved at låne 2 bits fra et /20 netværk?",
+    "expectedAnswer": "4",
+    "explanation": "2 ekstra subnet-bits giver 2^2 = 4 subnets ud af /20-netværket."
+  },
+  {
+    "id": 47,
+    "category": "Blokstørrelse",
+    "prompt": "Hvad er blokstørrelsen (antal adresser) for et /21 subnet?",
+    "expectedAnswer": "2048",
+    "explanation": "Et /21 efterlader 11 værtsbits: 2^11 = 2048 adresser i alt."
+  },
+  {
+    "id": 48,
+    "category": "Broadcast",
+    "prompt": "Hvad er broadcast-adressen for subnettet 192.168.60.32/28?",
+    "expectedAnswer": "192.168.60.47",
+    "explanation": "Et /28 har blokstørrelse 16. Intervallet 32-47 slutter med broadcast-adressen 192.168.60.47."
+  },
+  {
+    "id": 49,
+    "category": "Teori",
+    "prompt": "Hvor mange værtsbits er til rådighed i et subnet med prefix /18?",
+    "expectedAnswer": "14",
+    "explanation": "Et /18 betyder 18 netværksbits og 14 værtsbits (32 - 18 = 14)."
+  },
+  {
+    "id": 50,
+    "category": "Opsummering",
+    "prompt": "Hvilket summariseret netværk dækker subnettene 192.168.8.0/24 til 192.168.11.0/24?",
+    "expectedAnswer": "192.168.8.0/22",
+    "explanation": "Fire sammenhængende /24-net kan samles til ét /22: 192.168.8.0-192.168.11.255."
   }
 ]

--- a/index.php
+++ b/index.php
@@ -8,13 +8,13 @@
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen">
-  <div id="app" class="py-6 px-4 md:px-8 lg:px-12">
+  <div id="app" class="py-6 px-4 md:px-8 lg:px-12 w-full">
     <header class="mb-6 text-center">
       <h1 class="text-3xl font-bold text-indigo-900">Subnetting Forklaring</h1>
       <p class="text-gray-600 text-sm">Hvorfor og hvordan opdeler vi netværk?</p>
     </header>
     <section id="progress" class="mb-4"></section>
-    <section id="visualization" class="bg-white rounded-xl shadow-lg p-4 md:p-6 min-h-[520px] overflow-hidden"></section>
+    <section id="visualization" class="bg-white rounded-xl shadow-lg p-4 md:p-6 min-h-[520px] overflow-x-hidden w-full"></section>
     <section id="calculator" class="mt-4"></section>
     <footer class="mt-4 flex flex-wrap gap-3 items-center justify-between">
       <button id="prev-step" class="btn" type="button">← Forrige</button>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Subnetting Forklaring</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body class="bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen">
+  <div id="app" class="py-6">
+    <div class="max-w-6xl mx-auto px-4">
+      <header class="mb-4 text-center">
+        <h1 class="text-3xl font-bold text-indigo-900">Subnetting Forklaring</h1>
+        <p class="text-gray-600 text-sm">Hvorfor og hvordan opdeler vi netværk?</p>
+      </header>
+      <section id="progress" class="mb-4"></section>
+      <section id="visualization" class="bg-white rounded-xl shadow-lg p-4 md:p-6 min-h-[520px] overflow-hidden"></section>
+      <section id="calculator" class="mt-4"></section>
+      <footer class="mt-4 flex items-center justify-between">
+        <button id="prev-step" class="btn" type="button">← Forrige</button>
+        <div id="step-indicator" class="text-sm font-semibold text-gray-600"></div>
+        <button id="next-step" class="btn-primary" type="button">Næste →</button>
+      </footer>
+    </div>
+  </div>
+  <script src="assets/app.js"></script>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -8,21 +8,19 @@
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body class="bg-gradient-to-br from-blue-50 to-indigo-100 min-h-screen">
-  <div id="app" class="py-6">
-    <div class="max-w-6xl mx-auto px-4">
-      <header class="mb-4 text-center">
-        <h1 class="text-3xl font-bold text-indigo-900">Subnetting Forklaring</h1>
-        <p class="text-gray-600 text-sm">Hvorfor og hvordan opdeler vi netværk?</p>
-      </header>
-      <section id="progress" class="mb-4"></section>
-      <section id="visualization" class="bg-white rounded-xl shadow-lg p-4 md:p-6 min-h-[520px] overflow-hidden"></section>
-      <section id="calculator" class="mt-4"></section>
-      <footer class="mt-4 flex items-center justify-between">
-        <button id="prev-step" class="btn" type="button">← Forrige</button>
-        <div id="step-indicator" class="text-sm font-semibold text-gray-600"></div>
-        <button id="next-step" class="btn-primary" type="button">Næste →</button>
-      </footer>
-    </div>
+  <div id="app" class="py-6 px-4 md:px-8 lg:px-12">
+    <header class="mb-6 text-center">
+      <h1 class="text-3xl font-bold text-indigo-900">Subnetting Forklaring</h1>
+      <p class="text-gray-600 text-sm">Hvorfor og hvordan opdeler vi netværk?</p>
+    </header>
+    <section id="progress" class="mb-4"></section>
+    <section id="visualization" class="bg-white rounded-xl shadow-lg p-4 md:p-6 min-h-[520px] overflow-hidden"></section>
+    <section id="calculator" class="mt-4"></section>
+    <footer class="mt-4 flex flex-wrap gap-3 items-center justify-between">
+      <button id="prev-step" class="btn" type="button">← Forrige</button>
+      <div id="step-indicator" class="text-sm font-semibold text-gray-600"></div>
+      <button id="next-step" class="btn-primary" type="button">Næste →</button>
+    </footer>
   </div>
   <script src="assets/app.js"></script>
 </body>

--- a/index.php
+++ b/index.php
@@ -22,6 +22,9 @@
       <button id="next-step" class="btn-primary" type="button">Næste →</button>
     </footer>
   </div>
+  <footer class="site-footer">
+    <p class="site-footer__text">Steen Hansen - Techcollege</p>
+  </footer>
   <script src="assets/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the React-only subnetting simulator with a PHP-friendly entry point
- add Tailwind-powered HTML/CSS layout that mirrors the original walkthrough
- implement vanilla JavaScript interactions, animation, and subnet calculator

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ecfa91be98832aaddb6961e495292c