### PR TITLE
Remove subnetting tutorial from landing page

### DIFF
--- a/app.js
+++ b/app.js
@@ -122,7 +122,7 @@ function setupAntiCopy() {
 }
 
 function moderateClientSide(message) {
-    const whitelist = ['ai', 'undervis', 'differentier', 'subnet', 'netværk', 'programmer', 'prompt', 'dns', 'dhcp', 'kritisk', 'læring'];
+    const whitelist = ['ai', 'undervis', 'differentier', 'netværk', 'programmer', 'prompt', 'dns', 'dhcp', 'kritisk', 'læring', 'didakt', 'dannelse', 'feedback'];
     const normalized = message.toLowerCase();
     return whitelist.some((keyword) => normalized.includes(keyword));
 }
@@ -148,7 +148,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!message) return;
 
         if (!moderateClientSide(message)) {
-            addMessage('bot', 'Spørgsmålet ligger uden for sidens fokus. Prøv igen med et emne om AI, subnetting, programmering eller differentiering.');
+            addMessage('bot', 'Spørgsmålet ligger uden for sidens fokus. Prøv igen med et emne om AI i undervisning, didaktik, programmering eller differentiering.');
             chatInput.value = '';
             return;
         }

--- a/app.js
+++ b/app.js
@@ -1,0 +1,165 @@
+const modal = document.getElementById('modal');
+const modalBody = document.getElementById('modal-body');
+const modalClose = document.querySelector('.modal-close');
+const chatWindow = document.getElementById('chat-window');
+const chatForm = document.getElementById('chat-form');
+const chatInput = document.getElementById('chat-input');
+const glossarySearch = document.getElementById('glossary-search');
+const glossaryList = document.getElementById('glossary-list');
+
+function openModal(content) {
+    modalBody.textContent = content;
+    modal.removeAttribute('hidden');
+}
+
+function closeModal() {
+    modal.setAttribute('hidden', '');
+}
+
+function addMessage(role, text) {
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('message', role);
+    const bubble = document.createElement('div');
+    bubble.classList.add('bubble');
+    bubble.textContent = text;
+    wrapper.appendChild(bubble);
+    chatWindow.appendChild(wrapper);
+    chatWindow.scrollTop = chatWindow.scrollHeight;
+}
+
+async function fetchExplanation(term) {
+    modalBody.textContent = `Henter kort forklaring om ${term}...`;
+    modal.removeAttribute('hidden');
+    try {
+        const response = await fetch('proxy.php', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                type: 'glossary',
+                term
+            })
+        });
+
+        if (!response.ok) {
+            throw new Error('Uventet svar fra serveren.');
+        }
+
+        const data = await response.json();
+        if (data.error) {
+            openModal(`Beklager, der opstod en fejl: ${data.error}`);
+            return;
+        }
+
+        modalBody.textContent = data.answer;
+        modal.removeAttribute('hidden');
+    } catch (error) {
+        modalBody.textContent = 'Serveren kunne ikke hente forklaringen lige nu. Prøv igen senere.';
+        modal.removeAttribute('hidden');
+    }
+}
+
+async function sendChatMessage(message) {
+    addMessage('user', message);
+    addMessage('bot', 'Tænker over dit spørgsmål...');
+
+    try {
+        const response = await fetch('proxy.php', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                type: 'chat',
+                message
+            })
+        });
+
+        if (!response.ok) {
+            throw new Error('Der opstod et problem med forbindelsen.');
+        }
+
+        const data = await response.json();
+        chatWindow.removeChild(chatWindow.lastElementChild);
+
+        if (data.error) {
+            addMessage('bot', data.error);
+            return;
+        }
+
+        addMessage('bot', data.answer);
+    } catch (error) {
+        chatWindow.removeChild(chatWindow.lastElementChild);
+        addMessage('bot', 'Jeg kunne ikke hente svar fra serveren. Tjek din forbindelse og prøv igen.');
+    }
+}
+
+function filterGlossary(event) {
+    const value = event.target.value.toLowerCase();
+    const items = glossaryList.querySelectorAll('li');
+    items.forEach((item) => {
+        const term = item.querySelector('.glossary-term').textContent.toLowerCase();
+        const definition = item.querySelector('.definition').textContent.toLowerCase();
+        const visible = term.includes(value) || definition.includes(value);
+        item.style.display = visible ? '' : 'none';
+    });
+}
+
+function setupAntiCopy() {
+    document.addEventListener('contextmenu', (event) => {
+        event.preventDefault();
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if ((event.ctrlKey || event.metaKey) && ['c', 'x', 's', 'u'].includes(event.key.toLowerCase())) {
+            event.preventDefault();
+        }
+        if (event.key === 'PrintScreen') {
+            event.preventDefault();
+        }
+    });
+}
+
+function moderateClientSide(message) {
+    const whitelist = ['ai', 'undervis', 'differentier', 'subnet', 'netværk', 'programmer', 'prompt', 'dns', 'dhcp', 'kritisk', 'læring'];
+    const normalized = message.toLowerCase();
+    return whitelist.some((keyword) => normalized.includes(keyword));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.term').forEach((termEl) => {
+        termEl.addEventListener('click', () => {
+            const term = termEl.dataset.term || termEl.textContent.trim();
+            fetchExplanation(term);
+        });
+    });
+
+    modalClose.addEventListener('click', closeModal);
+    modal.addEventListener('click', (event) => {
+        if (event.target === modal) {
+            closeModal();
+        }
+    });
+
+    chatForm.addEventListener('submit', (event) => {
+        event.preventDefault();
+        const message = chatInput.value.trim();
+        if (!message) return;
+
+        if (!moderateClientSide(message)) {
+            addMessage('bot', 'Spørgsmålet ligger uden for sidens fokus. Prøv igen med et emne om AI, subnetting, programmering eller differentiering.');
+            chatInput.value = '';
+            return;
+        }
+
+        sendChatMessage(message);
+        chatInput.value = '';
+    });
+
+    if (glossarySearch) {
+        glossarySearch.addEventListener('input', filterGlossary);
+    }
+
+    setupAntiCopy();
+});

--- a/config.php
+++ b/config.php
@@ -13,12 +13,14 @@ $ALLOWED_TOPICS = [
     'ai',
     'undervisning',
     'differentiering',
-    'subnetting',
+    'didaktik',
     'netværk',
     'programmering',
     'prompting',
     'dhcp',
     'dns',
     'kritisk tænkning',
-    'læring'
+    'læring',
+    'dannelse',
+    'feedback'
 ];

--- a/config.php
+++ b/config.php
@@ -1,0 +1,24 @@
+<?php
+// Gem din OpenAI API-nøgle her og sørg for, at filen ikke er tilgængelig fra webserverens dokumentrod.
+$OPENAI_API_KEY = 'SK-ERSTAT-MED-DIN-NØGLE';
+
+// Domæner der må sende forespørgsler til proxyen.
+$ALLOWED_REFERERS = [
+    'http://localhost',
+    'https://localhost'
+];
+
+// Tilladte emner og nøgleord for moderationen.
+$ALLOWED_TOPICS = [
+    'ai',
+    'undervisning',
+    'differentiering',
+    'subnetting',
+    'netværk',
+    'programmering',
+    'prompting',
+    'dhcp',
+    'dns',
+    'kritisk tænkning',
+    'læring'
+];

--- a/index.html
+++ b/index.html
@@ -13,14 +13,14 @@
         <p>Af Steen Hansen og Heino K Jensen – erfaringer fra ungdomsuddannelser med både helt unge og voksne elever</p>
         <nav class="site-nav">
             <a href="#forord">Forord</a>
-            <a href="#kapitel-1">Kapitel 1</a>
-            <a href="#kapitel-2">Kapitel 2</a>
-            <a href="#kapitel-3">Kapitel 3</a>
-            <a href="#kapitel-4">Kapitel 4</a>
-            <a href="#kapitel-6">Kapitel 6</a>
-            <a href="#kapitel-8">Kapitel 8</a>
-            <a href="#kapitel-10">Kapitel 10</a>
-            <a href="#kapitel-11">Kapitel 11</a>
+            <a href="#kapitel-1">Kapitel 1 – Hvad er AI i undervisningskontekst?</a>
+            <a href="#kapitel-2">Kapitel 2 – Kritiske perspektiver: Etik, risici og ansvar</a>
+            <a href="#kapitel-3">Kapitel 3 – Vores erfaringer med undervisningen og hvorfor vi gør som vi gør</a>
+            <a href="#kapitel-4">Kapitel 4 – Vores strategi og de pædagogiske gevinster</a>
+            <a href="#kapitel-6">Kapitel 6 – Didaktiske designmønstre med AI</a>
+            <a href="#kapitel-8">Kapitel 8 – Promptteknik og hvorfor det er vigtigt</a>
+            <a href="#kapitel-10">Kapitel 10 – Implementering</a>
+            <a href="#kapitel-11">Kapitel 11 – Typiske faldgruber og mine modtræk</a>
             <a href="#bilag">Bilag</a>
             <a href="#chat">Chat</a>
             <a href="#fagordbog">Fagordbog</a>
@@ -269,7 +269,7 @@
             <ul id="glossary-list">
                 <li><button class="glossary-term term" data-term="AI">AI</button><span class="definition">Kunstig intelligens, der kan analysere og generere indhold.</span></li>
                 <li><button class="glossary-term term" data-term="prompting">Prompting</button><span class="definition">At formulere spørgsmål eller instruktioner til en AI.</span></li>
-                <li><button class="glossary-term term" data-term="subnetting">Subnetting</button><span class="definition">Opdeling af et netværk i mindre segmenter.</span></li>
+                <li><button class="glossary-term term" data-term="didaktik">Didaktik</button><span class="definition">Planlægning og refleksion over, hvordan læring organiseres.</span></li>
                 <li><button class="glossary-term term" data-term="DHCP">DHCP</button><span class="definition">Automatisk tildeling af IP-adresser på et netværk.</span></li>
                 <li><button class="glossary-term term" data-term="DNS">DNS</button><span class="definition">Oversætter domænenavne til IP-adresser.</span></li>
                 <li><button class="glossary-term term" data-term="netværk">Netværk</button><span class="definition">Forbindelser mellem enheder, der deler data.</span></li>
@@ -280,7 +280,7 @@
 
         <section id="chat" class="section-card">
             <h2>Chat om sidens emner</h2>
-            <p>Brug chatten til at stille korte spørgsmål om <span class="term" data-term="AI">AI</span> i undervisning, subnetting, programmering, <span class="term" data-term="netværk">netværk</span>, <span class="term" data-term="prompting">prompting</span> eller differentiering. Andre emner bliver høfligt afvist. Svarene er på dansk og hjælper dig til selv at tænke videre.</p>
+            <p>Brug chatten til at stille korte spørgsmål om <span class="term" data-term="AI">AI</span> i undervisning, didaktik, programmering, <span class="term" data-term="netværk">netværk</span>, <span class="term" data-term="prompting">prompting</span> eller differentiering. Andre emner bliver høfligt afvist. Svarene er på dansk og hjælper dig til selv at tænke videre.</p>
             <div id="chat-window" aria-live="polite"></div>
             <form id="chat-form">
                 <label for="chat-input" class="sr-only">Skriv dit spørgsmål</label>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI i Undervisning – Interaktiv læringsside</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="site-header">
+        <h1>AI i Undervisning: Fra Nysgerrighed til Praksis</h1>
+        <p>Af Steen Hansen og Heino K Jensen – erfaringer fra ungdomsuddannelser med både helt unge og voksne elever</p>
+        <nav class="site-nav">
+            <a href="#forord">Forord</a>
+            <a href="#kapitel-1">Kapitel 1</a>
+            <a href="#kapitel-2">Kapitel 2</a>
+            <a href="#kapitel-3">Kapitel 3</a>
+            <a href="#kapitel-4">Kapitel 4</a>
+            <a href="#kapitel-6">Kapitel 6</a>
+            <a href="#kapitel-8">Kapitel 8</a>
+            <a href="#kapitel-10">Kapitel 10</a>
+            <a href="#kapitel-11">Kapitel 11</a>
+            <a href="#bilag">Bilag</a>
+            <a href="#chat">Chat</a>
+            <a href="#fagordbog">Fagordbog</a>
+        </nav>
+    </header>
+
+    <main>
+        <section id="forord" class="section-card">
+            <h2>Forord</h2>
+            <p>Vi har arbejdet med <span class="term" data-term="AI">AI</span> i undervisning på ungdomsuddannelser – særligt erhvervs- og tekniske forløb – hvor holdene ofte rummer både helt unge elever og voksne med erfaring fra arbejde eller tidligere uddannelser. Det her er min praktiske vejledning: hvad virker i hverdagen, hvad bør man undgå, og hvordan får man ro på processen, så <span class="term" data-term="AI">AI</span> bliver et pædagogisk plus – ikke endnu et forstyrrende værktøj.</p>
+            <p>Vores grundidé er enkel: <strong><span class="term" data-term="AI">AI</span> skal ikke løse opgaven for eleverne – <span class="term" data-term="AI">AI</span> skal hjælpe dem med at tænke.</strong> Det kræver bevidste rammer, tydelige opgaver og en lærer, der tør være kritisk sparringspartner. På GF2 Data har vi brugt <span class="term" data-term="AI">AI</span> til at differentiere og motivere vores elever til selv at tage initiativ til at lære i eget tempo og uden ventetid. 
+<span class="term" data-term="AI">AI</span> er ikke et mirakelmiddel, men det kan helt sikkert være et værktøj, der – hvis det bruges rigtigt – har potentiale til at forbedre elevernes gennemførsel på uddannelserne.</p>
+            <p>I dette dokument vil du møde eksempler og øvelser, der udspringer af erfaringer fra datauddannelserne, og som viser, hvordan <span class="term" data-term="AI">AI</span> kan bruges i praksis til at skabe motivation, struktur og ejerskab hos eleverne.</p>
+            <p>Vores motto er "Kast dig ud i det, tro på det, evaluer og tilpas."</p>
+        </section>
+
+        <section id="kapitel-1" class="section-card">
+            <h2>Kapitel 1 – Hvad er AI i undervisningskontekst?</h2>
+            <p><span class="term" data-term="AI">AI</span> er ikke én ting, men en familie af værktøjer, der kan analysere, foreslå, generere og forklare. I undervisning er pointen ikke teknologien i sig selv, men hvad den gør for faglighed, differentiering og dannelse.</p>
+            <h3>1.1 <span class="term" data-term="AI">AI</span> som pædagogisk værktøj</h3>
+            <ul>
+                <li><strong>Generere materiale</strong>: opgaveidéer, cases, quizzer, billeder.</li>
+                <li><strong>Tilpasse forklaringer</strong>: samme faglige kerne i flere sværhedsgrader (rød/gul/grøn).</li>
+                <li><strong>Støtte refleksion</strong>: stille modspørgsmål, afklare begreber, foreslå næste skridt.</li>
+                <li><strong>Træning</strong>: micro-øvelser, flashcards, kodeforklaring, mundtlig træning.</li>
+                <li><strong>Første feedback</strong>: tjeklister og “forbedr det her”-forslag, før læreren giver endelig feedback.</li>
+            </ul>
+            <h3>1.2 <span class="term" data-term="AI">AI</span> som didaktisk partner</h3>
+            <p><span class="term" data-term="AI">AI</span> kan lette idéfasen i planlægning, hjælpe med differentiering og skabe struktur i forløb. Men lærerens dømmekraft er uerstattelig: vi sætter mål, rammer og evaluering.</p>
+            <h3>1.3 Tre niveauer af brug (til kolleger)</h3>
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Niveau</th>
+                        <th>Kendetegn</th>
+                        <th>Mit fokus med dig</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Begynder</td>
+                        <td>Har prøvet <span class="term" data-term="AI">AI</span> lidt, usikker på “hvordan starter jeg?”</td>
+                        <td>Trygge første skridt, skabeloner, små prøvehandlinger.</td>
+                    </tr>
+                    <tr>
+                        <td>Øvet</td>
+                        <td>Bruger <span class="term" data-term="AI">AI</span> jævnligt, vil bruge det mere målrettet</td>
+                        <td>Differentiering, feedback, dokumentation af læring.</td>
+                    </tr>
+                    <tr>
+                        <td>Erfaren</td>
+                        <td>Har integreret <span class="term" data-term="AI">AI</span>, vil løfte kvalitet og etik</td>
+                        <td>Designmønstre, elevkontrakter, evaluering, skalerbarhed.</td>
+                    </tr>
+                </tbody>
+            </table>
+            <h3>1.4 Kritisk tænkning og didaktisk ansvar</h3>
+            <p><span class="term" data-term="AI">AI</span> må ikke fjerne modstanden i læring. Vi skal bevare opgaver, hvor eleven <strong>forklarer, begrunder, afprøver og reviderer</strong> – og hvor <span class="term" data-term="AI">AI</span> er et <strong>redskab til at tænke</strong>, ikke en genvej uden om tænkning.</p>
+        </section>
+
+        <section id="kapitel-2" class="section-card">
+            <h2>Kapitel 2 – Kritiske perspektiver: Etik, risici og ansvar</h2>
+            <p>Jeg starter her, fordi troværdigheden vokser, når vi tager udfordringerne alvorligt.</p>
+            <h3>2.1 Overafhængighed</h3>
+            <p><span class="term" data-term="AI">AI</span> kan føles som en “nem knap”. Derfor designer jeg opgaver, hvor <span class="term" data-term="AI">AI</span> må bruges til <strong>forklaring og forbedring</strong>, men ikke til at levere hele svaret uden elevens spor. Eksempel: “Brug <span class="term" data-term="AI">AI</span> til at finde alternative vinkler – og skriv bagefter med dine egne ord, hvad du vælger og hvorfor.”</p>
+            <h3>2.2 Bias og uigennemsigtighed</h3>
+            <p><span class="term" data-term="AI">AI</span> er trænet på data – ikke sandhed. Jeg forsøger og opfordrer eleverne til at:</p>
+            <ul>
+                <li>spørge <em>hvor påstanden kommer fra?</em></li>
+                <li>sammenligne svar med andre kilder,</li>
+                <li>skelne mellem sandsynlighed og sikker viden.</li>
+            </ul>
+            <h3>2.3 Datasikkerhed og privatliv</h3>
+            <p>Del aldrig persondata, interne dokumenter eller prøvemateriale i åbne <span class="term" data-term="AI">AI</span>-tjenester. Tommelfingerregel: <strong>Hvis du ikke ville sende det til hele skolen på mail, så skal det heller ikke i <span class="term" data-term="AI">AI</span>.</strong></p>
+            <h3>2.4 Dannelse</h3>
+            <p>Dannelse kræver modstand, nysgerrighed og dialog. Brug <span class="term" data-term="AI">AI</span> til at åbne flere perspektiver – ikke til at lukke diskussionen. Lad eleverne sammenligne <span class="term" data-term="AI">AI</span>’s svar med egne ideer og begrunde forskelle.</p>
+            <h3>2.5 Lærerens professionelle ansvar</h3>
+            <p>Spørg altid: <em>Hvorfor <span class="term" data-term="AI">AI</span> her? Hvilken gevinst giver det? Hvilken risiko følger med?</em> Vælg bevidst – ikke automatisk.</p>
+        </section>
+
+        <section id="kapitel-3" class="section-card">
+            <h2>Kapitel 3 – Vores erfaringer med undervisningen og hvorfor vi gør som vi gør</h2>
+            <p>Vi vil i dette kapitel dele vores egne erfaringer og refleksioner om, hvordan og hvorfor vi underviser, som vi gør. <span class="term" data-term="AI">AI</span> har ikke været et separat projekt – det har været en naturlig udvikling af vores måde at arbejde med eleverne på.</p>
+            <p>Efter de første 5-6 uger af grundforløbet, hvor eleverne møder en mere traditionel struktur, begynder vi gradvist at slippe dem fri. Vi kalder det vores <strong>differentierede fase</strong>, hvor <span class="term" data-term="AI">AI</span> og selvstændighed bliver omdrejningspunktet.</p>
+            <h3>Hvordan vi underviser</h3>
+            <p>Vi har samlet to klasser til ét hold uden fast skema. Det betyder, at eleverne ikke længere følger separate fag som server, <span class="term" data-term="netværk">netværk</span>, programmering og IT-kendskab – de arbejder i stedet med <strong>datafag</strong> som en samlet helhed. Hver elev vælger dag for dag, hvad han eller hun har mest behov for eller lyst til at arbejde med. Vi som undervisere koordinerer og tilbyder små sessioner, når vi ser et behov – det kan være én elev, fem elever eller hele holdet.</p>
+            <p>Vores erfaring er, at det skaber ro og ejerskab. Eleverne føler, de har ansvar for egen læring, og de oplever, at undervisningen passer bedre til dem. For os betyder det, at vi kan bruge tiden dér, hvor den gør størst forskel.</p>
+            <h3>Hvorfor vi gør det</h3>
+            <p>Før vi ændrede strukturen, oplevede vi et klassisk mønster: omkring en tredjedel af eleverne syntes undervisningen var for svær, en tredjedel syntes den var passende, og den sidste tredjedel kedede sig. Vi ønskede at bryde det mønster. <span class="term" data-term="AI">AI</span> blev katalysatoren, fordi det gjorde det muligt at give støtte og udfordring i samme rum – men på forskellige niveauer.</p>
+            <p>De stærke elever kan bruge <span class="term" data-term="AI">AI</span> til at udforske avancerede problemstillinger, mens de, der kæmper, får forklaret begreberne på nye måder, indtil de forstår dem. Ingen skal vente – alle kan arbejde i deres eget tempo.</p>
+            <h3>Vores platform og materialer</h3>
+            <p>Vi har opbygget hele vores struktur omkring SharePoint-siden <strong>"Grundforløbsinformation Data GF2"</strong>, som fungerer som vores digitale samlingspunkt. Her finder eleverne ugeplaner, flashkort, læringsmål, opgaver og praktiske ressourcer. Siden gør, at alle elever – uanset niveau – altid kan finde noget at arbejde med. Vi oplever, at denne gennemsigtighed giver tryghed og ansvarsfølelse.</p>
+            <p>Til hvert fagområde har vi et hoveddokument, som dækker det væsentlige (omkring 75 % <span class="term" data-term="AI">AI</span>-genereret). Derudover har vi et omfattende bibliotek af supplerende materialer, så eleverne kan vælge mellem videoer, tutorials, tekst og øvelser. Denne differentiering gør, at vi kan møde eleverne der, hvor de er, og støtte dem i at bevæge sig fremad.</p>
+            <h3>Vores læringsmiljø og udvikling af undervisningen</h3>
+            <p>Vi er gået fra en mere teoretisk klasseundervisning til nu at have udstyr og materialer som computere og routere til alle grupper. Det betyder, at eleverne kan arbejde praktisk og eksperimentere med virkelige <span class="term" data-term="netværk">netværk</span>sscenarier, mens de samtidig anvender <span class="term" data-term="AI">AI</span> som vejledning og refleksionspartner.</p>
+            <p>Længere henne i forløbet arbejder eleverne i løse grupper. Nogle vælger at arbejde meget sammen, mens andre foretrækker at arbejde alene eller to og to. Denne fleksibilitet gør det muligt for hver elev at finde den arbejdsform, der passer bedst til deres læringsstil. Vi oplever, at denne blanding skaber både ro og faglig fordybelse.</p>
+            <p>Der er i forløbet indlagt 3-4 større faglige projekter, hvor eleverne arbejder på tværs af fagene. I det første projekt bestemmer vi gruppesammensætningen, så eleverne lærer at samarbejde på tværs. I de senere projekter vælger de selv, hvem de arbejder med. Vi observerer løbende og justerer, hvis grupperne ikke fungerer optimalt – så alle har de bedste forudsætninger for at lære.</p>
+            <p>Vi er som sagt to undervisere og to klasser, der deler to lokaler adskilt af en åben foldedør. For at få undervisningen til at hænge sammen er vi nødt til at have rådighed over et ekstra lokale, hvor vi kan gennemføre mere teoretiske oplæg eller individuelle samtaler uden at forstyrre det praktiske arbejde. Det, andre kalder “værkstedet”, er for os et fuldt udstyret læringsrum, hvor eleverne arbejder med alt fra serveropsætning til fejlfinding på <span class="term" data-term="netværk">netværk</span>. Det ekstra lokale fungerer som vores stillezone og refleksionsrum, hvor vi kan samle mindre grupper eller enkelte elever til fokuseret teori og vejledning.</p>
+            <h3>Effekten af vores tilgang</h3>
+            <p>Resultatet har været tydeligt: Eleverne arbejder mere selvstændigt, flere gennemfører, og stemningen i klassen er markant bedre. Vi ser færre, der “zoomer ud”, og flere, der tager initiativ. Eleverne fortæller selv, at de oplever mere frihed, men også mere ansvar – fordi de ved, at de altid kan finde hjælp, når de har brug for den.</p>
+            <p>En elev sagde det meget præcist: <em>“Det føles ikke som skole, det føles som at lære.”</em> Og netop det er essensen af vores tilgang.</p>
+            <p><span class="term" data-term="AI">AI</span> har givet os mulighed for at vende undervisningen på hovedet – ikke ved at fjerne læreren, men ved at give plads til, at eleverne lærer på deres egen måde, i deres eget tempo og med vores støtte, når det giver mening.</p>
+            <p>Vi når naturligvis ikke alle elever, og vi laver ingen mirakler. Nogle elever kæmper stadig, uanset hvor fleksibel undervisningen er. Vi er dog særligt opmærksomme på dem, og når vi fornemmer, at en elev mister fodfæstet, inviterer vi til en personlig samtale – en mundtlig evaluering. Her handler det ikke om at vurdere, men om at afklare: Vi viser eleven, hvor han eller hun står fagligt, og sammen laver vi en plan for næste skridt. På den måde bevarer vi relationen og sikrer, at ingen føler sig glemt. Selv med denne støtte når vi ikke alle elever. Nogle kæmper fortsat med personlige udfordringer eller kognitive begrænsninger, som gør læringen vanskeligere. Det er en realitet, vi møder med forståelse og faglig opmærksomhed.</p>
+        </section>
+
+        <section id="kapitel-4" class="section-card">
+            <h2>Kapitel 4 – Vores strategi og de pædagogiske gevinster</h2>
+            <p><span class="term" data-term="AI">AI</span> forstærker det, vi i forvejen gør godt: relationer, differentiering og tydelig faglig progression. Hvor tidligere læringsmodeller ofte arbejdede med faste rammer, åbner <span class="term" data-term="AI">AI</span> for en mere dynamisk og elevstyret tilgang.</p>
+            <p>Vores strategi er enkel: <strong>Eleverne skal kunne arbejde selvstændigt, men aldrig alene.</strong> <span class="term" data-term="AI">AI</span> er redskabet, der gør dette muligt.</p>
+            <p>Vi bruger <span class="term" data-term="AI">AI</span> i planlægningen til at skabe variation i materialer, formulere opgaver i flere sværhedsgrader og udvikle cases, der taler til elevernes virkelighed. Det betyder, at læreren får mere tid til relationer, coaching og faglig fordybelse.</p>
+            <p><span class="term" data-term="AI">AI</span> hjælper os med at skabe progression i undervisningen – fra guidet læring til selvstændig udforskning. Den pædagogiske gevinst ligger ikke i automatiseringen, men i frigørelsen: at læreren kan bruge sin tid dér, hvor menneskelig indsigt og relation betyder mest.</p>
+            <p>Vi oplever, at elevernes motivation vokser, når de kan vælge retning, men stadig mærker, at der er et tydeligt fagligt fundament. Det er her balancen ligger mellem frihed og struktur – et princip, der går igen i både Hatties og Vygotskys arbejde med læringens kvalitet og støtte.</p>
+            <p>Som praksiserfaring siger vi ofte: <em><span class="term" data-term="AI">AI</span> skal ikke tage arbejdet fra læreren – men give læreren tid til at undervise rigtigt.</em> – Vores erfaringer med undervisningen og hvorfor vi gør som vi gør.</p>
+            <p>Vi vil i dette kapitel dele vores egne erfaringer og refleksioner om, hvordan og hvorfor vi underviser, som vi gør. <span class="term" data-term="AI">AI</span> har ikke været et separat projekt – det har været en naturlig udvikling af vores måde at arbejde med eleverne på.</p>
+            <p>Efter de første 5-6 uger af grundforløbet, hvor eleverne møder en mere traditionel struktur, begynder vi gradvist at slippe dem fri. Vi kalder det vores <strong>differentierede fase</strong>, hvor <span class="term" data-term="AI">AI</span> og selvstændighed bliver omdrejningspunktet.</p>
+            <h3>Hvordan vi underviser</h3>
+            <p>Vi har samlet to klasser til ét hold uden fast skema. Det betyder, at eleverne ikke længere følger separate fag som server, <span class="term" data-term="netværk">netværk</span>, programmering og IT-kendskab – de arbejder i stedet med <strong>datafag</strong> som en samlet helhed. Hver elev vælger dag for dag, hvad han eller hun har mest behov for eller lyst til at arbejde med. Vi som undervisere koordinerer og tilbyder små sessioner, når vi ser et behov – det kan være én elev, fem elever eller hele holdet.</p>
+            <p>Vores erfaring er, at det skaber ro og ejerskab. Eleverne føler, de har ansvar for egen læring, og de oplever, at undervisningen passer bedre til dem. For os betyder det, at vi kan bruge tiden dér, hvor den gør størst forskel.</p>
+            <h3>Hvorfor vi gør det</h3>
+            <p>Før vi ændrede strukturen, oplevede vi et klassisk mønster: omkring en tredjedel af eleverne syntes undervisningen var for svær, en tredjedel syntes den var passende, og den sidste tredjedel kedede sig, det er for let. Vi ønskede at bryde det mønster. Blandt andet <span class="term" data-term="AI">AI</span> blev katalysatoren, fordi det gjorde det muligt at give støtte og udfordring i samme rum – men på forskellige niveauer.</p>
+            <p>De stærke elever kan bruge <span class="term" data-term="AI">AI</span> til at udforske avancerede problemstillinger, mens de, der kæmper, får forklaret begreberne på nye måder, indtil de forstår dem. Ingen skal vente – alle kan arbejde i deres eget tempo.</p>
+            <h3>Vores platform og materialer</h3>
+            <p>Vi har opbygget hele vores struktur omkring SharePoint-siden <strong>"Grundforløbsinformation Data GF2"</strong>, som fungerer som vores digitale samlingspunkt. Her finder eleverne ugeplaner, flashkort, læringsmål, opgaver og praktiske ressourcer. Siden gør, at alle elever – uanset niveau – altid kan finde noget at arbejde med. Vi oplever, at denne gennemsigtighed giver tryghed og ansvarsfølelse.</p>
+            <p>Til hvert fagområde har vi et hoveddokument, som dækker det væsentlige (omkring 75 % <span class="term" data-term="AI">AI</span>-genereret). Derudover har vi et omfattende bibliotek af supplerende materialer, så eleverne kan vælge mellem videoer, tutorials, tekst og øvelser. Denne differentiering gør, at vi kan møde eleverne der, hvor de er, og støtte dem i at bevæge sig fremad.</p>
+            <h3>Effekten af vores tilgang</h3>
+            <p>Resultatet har været tydeligt: Eleverne arbejder mere selvstændigt, flere gennemfører, og stemningen i klassen er markant bedre. Vi ser færre, der “zoomer ud”, og flere, der tager initiativ. Eleverne fortæller selv, at de oplever mere frihed, men også mere ansvar – fordi de ved, at de altid kan finde hjælp, når de har brug for den.</p>
+            <p>En elev sagde det meget præcist: <em>“Det føles ikke som skole, det føles som at lære.”</em> Og netop det er essensen af vores tilgang.</p>
+            <p><span class="term" data-term="AI">AI</span> har givet os mulighed for at vende undervisningen på hovedet – ikke ved at fjerne læreren, men ved at give plads til, at eleverne lærer på deres egen måde, i deres eget tempo og med vores støtte, når det giver mening.</p>
+        </section>
+
+        <section id="kapitel-6" class="section-card">
+            <h2>Kapitel 6 – Didaktiske designmønstre med AI</h2>
+            <p>I vores undervisning giver vi typisk ikke eleverne faste opgaver. I stedet guider vi dem til at finde den måde, de lærer bedst på gennem det materiale, vi stiller til rådighed – herunder øvelser, opgaver og ressourcer. Denne tilgang betyder, at eleverne lærer at tage ansvar for deres egen læringsproces, eksperimentere og opdage, hvad der virker for dem. Det gælder også opgaver: de vælger selv, hvordan de vil arbejde med stoffet, og hvordan de vil vise deres forståelse. På den måde bliver læring en personlig rejse frem for en række instruktioner, der skal følges.</p>
+            <p>Når vi ser på vores arbejde gennem designmønstre, handler det i praksis om at omsætte pædagogiske principper til konkrete læringssituationer. <span class="term" data-term="AI">AI</span> har givet os mulighed for at skabe strukturer, hvor eleverne gradvist får mere ansvar for egen læring – men med støtte hele vejen.</p>
+            <p>Vi bruger ikke designmønstre som teori, men som beskrivelser af, hvordan læring faktisk sker i vores klasserum. Mange af vores mønstre udspringer af erfaringer beskrevet i kapitel 4: de fleksible grupper, de åbne projekter og den løbende feedback. Herunder forklarer vi, hvordan det hænger sammen.</p>
+            <p>Når eleverne arbejder i løse grupper, ser vi en naturlig overgang mellem tre læringsfaser: først observerer de os (I-Do), derefter samarbejder de (We-Do), og til sidst tager de ejerskab (You-Do). Denne udvikling minder om modellen for <strong>gradvis frigivelse</strong> (Pearson &amp; Gallagher, 1983), hvor læreren starter med tydelig modellering og gradvist giver ansvaret videre. <span class="term" data-term="AI">AI</span> spiller en ny rolle i denne proces: den kan overtage dele af støtten i slutningen, så eleverne stadig føler sig trygge, selv når de arbejder selvstændigt.</p>
+            <p>Et konkret eksempel: Under et <span class="term" data-term="netværk">netværk</span>sprojekt begynder vi med en fælles demonstration af <span class="term" data-term="DHCP">DHCP</span> og IP-konfiguration. Herefter arbejder eleverne i små grupper, hvor <span class="term" data-term="AI">AI</span> bruges som hjælper til at forklare fejl og foreslå løsninger. Til sidst dokumenterer hver elev selv forløbet og forklarer deres valg – det er deres “You-Do”-moment. Vi husker samtidig, at eleverne ikke alle når til de samme begreber på samme tid. Vi introducerer først nye faglige begreber, når den enkelte elev eller gruppe er klar til det. Det betyder, at læringsforløbene ofte bliver forskudte – og det er helt bevidst. Det sker også, at vi tager hele holdet igennem et emne i for eksempel programmering, og senere gentager vi det for de elever, der måske ikke var helt med første gang. Denne fleksibilitet giver plads til gentagelse og fordybelse uden at stigmatisere eleverne – de møder stoffet, når det giver mening for dem.</p>
+            <p>I vores arbejde med <strong>rød/gul/grøn-modellen</strong> ser vi <span class="term" data-term="AI">AI</span> som katalysator for differentiering. Rød-eleverne får små, guidede trin og korte svar. Gul-eleverne får valgmuligheder og refleksionsspørgsmål. Grøn-eleverne får åbne udfordringer og opgaver, der kræver dokumenteret refleksion. <span class="term" data-term="AI">AI</span> hjælper os med at skabe og tilpasse disse trin hurtigt, så alle elever føler sig mødt. (Se fx Svejgaard, K., <em>Differentieret undervisning i praksis</em>, 2020.)</p>
+            <p>Teoretisk hviler vores designmønstre på <strong>Vygotskys zone for nærmeste udvikling</strong> – at elever lærer bedst, når de udfordres lige på grænsen af deres nuværende kompetence – og på <strong>Hatties forskning</strong> i synlig læring, der fremhæver feedback og relationer som de mest effektive læringsfaktorer (Hattie, 2009). I praksis betyder det, at vi designer opgaver, hvor <span class="term" data-term="AI">AI</span> giver hurtig feedback, mens vi bruger tiden på relation og refleksion.</p>
+            <p>Endelig trækker vi på erfaringer fra <strong>konstruktivistisk læringsteori</strong>, hvor viden opstår gennem aktivt engagement. Når eleverne bygger, fejlsøger og dokumenterer i vores værksted, bliver <span class="term" data-term="AI">AI</span> en del af den refleksive dialog – et værktøj til at undersøge egne hypoteser.</p>
+            <p>Kort sagt: Designmønstrene er ikke skemaer, men levende strukturer, der vokser ud af praksis. De er måden, vi forbinder teori, erfaring og teknologi på, så læring bliver både menneskelig og digital.</p>
+            <div class="interactive-panels">
+                <details>
+                    <summary>I-Do / We-Do / You-Do (gradvis frigivelse)</summary>
+                    <ul>
+                        <li><strong>I-Do</strong>: Læreren modellerer opgaven – <span class="term" data-term="AI">AI</span> bruges til at vise alternative forklaringer.</li>
+                        <li><strong>We-Do</strong>: Klassen løser delopgaver – <span class="term" data-term="AI">AI</span> bruges til tjeklister og “hvad overser vi?”.</li>
+                        <li><strong>You-Do</strong>: Eleven løser selv – <span class="term" data-term="AI">AI</span> kun som ordbog/idébank; fokus på elevens forklaring.</li>
+                    </ul>
+                </details>
+                <details>
+                    <summary>Rød/Gul/Grøn (Svejgaard-inspireret differentiering)</summary>
+                    <ul>
+                        <li><strong>Rød</strong>: Basale begreber + guidede skridt.</li>
+                        <li><strong>Gul</strong>: Standardforløb + valg mellem to spor.</li>
+                        <li><strong>Grøn</strong>: Udvidelse/udforskning + dokumenteret refleksion.</li>
+                    </ul>
+                </details>
+            </div>
+        </section>
+
+        <section id="kapitel-8" class="section-card">
+            <h2>Kapitel 8 – Promptteknik og hvorfor det er vigtigt</h2>
+            <p>At 'prompte' betyder at stille spørgsmål eller give instruktioner til en <span class="term" data-term="AI">AI</span> på en måde, der gør, at man får det bedst mulige svar. Det handler ikke om at kende den perfekte formulering, men om at turde stille spørgsmål, prøve sig frem og lære af processen. I vores undervisning har vi erfaret, at de bedste resultater kommer, når eleverne tør eksperimentere og justere deres prompts undervejs – præcis som når de tester og fejlfinder i programmering.</p>
+            <p>Vi plejer at sige: <em>Det vigtigste er ikke, at du gør det rigtigt – det vigtigste er, at du gør det.</em> For med øvelse kommer forståelsen. At prompte er en praktisk færdighed, hvor fejl er en del af læringen. Når eleverne opdager, hvordan små ændringer i sproget kan give store forskelle i svaret, udvikler de både deres nysgerrighed og deres evne til at tænke kritisk.</p>
+            <p>Prompts er altså ikke magiske formler – de er en måde at starte en dialog på. Målet er ikke at få <span class="term" data-term="AI">AI</span> til at levere svaret, men at bruge samtalen til at forstå emnet bedre. Derfor er <span class="term" data-term="prompting">prompting</span> i sig selv en læringsproces, hvor både elever og lærere bliver klogere på, hvordan spørgsmål former viden.</p>
+            <h3>Eksempler på prompts</h3>
+            <ol class="prompt-list">
+                <li><strong>A. Differentieret forklaring (indsæt dit emne)</strong><br>
+                    <blockquote>Forklar [EMNE] i tre niveauer: rød (helt enkelt), gul (standard), grøn (udvidet). Brug korte eksempler fra [FAG/BRANCHE]. Slut med tre kontrolspørgsmål pr. niveau.</blockquote>
+                </li>
+                <li><strong>B. Kritisk ven til elevrapport</strong><br>
+                    <blockquote>Stil 5 præcise, kritiske spørgsmål til denne tekst, så forfatteren opdager svage steder. Foreslå 3 konkrete forbedringer pr. spørgsmål. Giv ikke færdige formuleringer.</blockquote>
+                </li>
+                <li><strong>C. Første feedback på dokumentation</strong><br>
+                    <blockquote>Tjek min dokumentation af [OPGAVE] mod en tjekliste med 8 punkter (konkrete skærmbilleder, valg begrundet, typiske fejl). Peg på 3 huller og stil ét nysgerrigt spørgsmål pr. hul.</blockquote>
+                </li>
+                <li><strong>D. Debug uden facit (kode)</strong><br>
+                    <blockquote>Hjælp mig med at forstå denne fejlmeddelelse. Forklar hvad den betyder, hvilke linjer jeg bør se på, og hvilke to hypoteser jeg kan teste. Giv ikke løsningen.</blockquote>
+                </li>
+                <li><strong>E. Mundtlig træning</strong><br>
+                    <blockquote>Spil rollen som [BORGER/KUNDE/KOLLEGA] med disse karaktertræk: [..]. Giv mig korte svar, ét ad gangen. Evaluer til sidst med 3 styrker og 2 forbedringsforslag.</blockquote>
+                </li>
+            </ol>
+        </section>
+
+        <section id="kapitel-10" class="section-card">
+            <h2>Kapitel 10 – Implementering</h2>
+            <ul>
+                <li>En lille prøvehandling i hvert fagteam.</li>
+                <li>Klassens <span class="term" data-term="AI">AI</span>-regler og elevkontrakt.</li>
+                <li>Indsamling af før/efter-eksempler.</li>
+                <li>Udvid én prøvehandling til et mini-forløb.</li>
+                <li>Kollegial visning af elevprodukter og logbog.</li>
+                <li>Konsolider det, der virker.</li>
+                <li>Skriv korte standardskabeloner og del i teamet.</li>
+                <li>Planlæg næste iteration (nye fag/hold).</li>
+            </ul>
+        </section>
+
+        <section id="kapitel-11" class="section-card">
+            <h2>Kapitel 11 – Typiske faldgruber og mine modtræk</h2>
+            <ul>
+                <li><strong>For brede prompts</strong> → Brug mål, kontekst og begrænsninger. Bed om tjekliste, ikke færdige svar.</li>
+                <li><strong>Elever kopierer <span class="term" data-term="AI">AI</span>-tekst</strong> → Kræv <span class="term" data-term="AI-notat">AI-notat</span> + mini-mundtlig forklaring.</li>
+                <li><strong>For meget <span class="term" data-term="AI">AI</span>, for lidt dialog</strong> → Læg indlagte stop: makkerlæsning, tavs tænkepause, stand-up forklaringer.</li>
+                <li><strong>Tidsforbrug for læreren</strong> → Genbrug dine bedste <span class="term" data-term="prompting">prompts</span> og skabeloner. Del i teamet. Start småt.</li>
+            </ul>
+        </section>
+
+        <section id="bilag" class="section-card">
+            <h2>Bilag</h2>
+            <h3>Bilag A – Skabelon: <span class="term" data-term="AI">AI</span>-prøvehandling (one-pager)</h3>
+            <p><strong>Titel &amp; fag:</strong><br>
+            <strong>Mål (max 3):</strong><br>
+            <strong><span class="term" data-term="AI">AI</span>-rollen (tilladt/forbudt):</strong><br>
+            <strong>Aktivitet (trinvis):</strong><br>
+            <strong>Evidens der indsamles:</strong><br>
+            <strong>Kriterier for succes:</strong><br>
+            <strong>Risici &amp; modtræk:</strong><br>
+            <strong>Tidslinje og ansvar:</strong></p>
+
+            <h3>Bilag B – Skabelon: Elevens <span class="term" data-term="AI">AI</span>-notat (til aflevering)</h3>
+            <ol>
+                <li>Hvad bad jeg <span class="term" data-term="AI">AI</span> om – og hvorfor?</li>
+                <li>Hvad ændrede jeg i mit produkt pga. <span class="term" data-term="AI">AI</span>?</li>
+                <li>Hvad forstår jeg nu bedre – og hvad mangler jeg stadig?</li>
+            </ol>
+
+            <h3>Bilag D – Hurtige klasseregler (plakat)</h3>
+            <ul>
+                <li>Brug <span class="term" data-term="AI">AI</span> til at <strong>forstå</strong> og <strong>forbedre</strong> – ikke til at <strong>aflevere</strong> for dig.</li>
+                <li>Skriv altid et kort <strong><span class="term" data-term="AI">AI</span>-notat</strong> i din aflevering.</li>
+                <li>Del ikke persondata.</li>
+                <li>Kun det, du kan forklare, bliver godkendt.</li>
+            </ul>
+
+            <h3>Efterskrift</h3>
+            <p><span class="term" data-term="AI">AI</span> ændrer ikke målet med undervisning – det skærper vores opgave: at hjælpe elever (unge og voksne) til at tænke selvstændigt, samarbejde klogt med værktøjer og tage ansvar for eget arbejde. Start småt, vær nysgerrig, dokumentér hvad der sker – og del erfaringerne. Det er sådan, kvaliteten vokser.</p>
+        </section>
+
+        <section id="fagordbog" class="section-card">
+            <h2>Fagordbog</h2>
+            <p>Søg efter et fagord og klik for at få en forklaring. Forklaringerne hentes kort fra <span class="term" data-term="AI">AI</span>, så du kan reflektere videre.</p>
+            <input type="text" id="glossary-search" placeholder="Søg i fagord..." aria-label="Søg i fagord">
+            <ul id="glossary-list">
+                <li><button class="glossary-term term" data-term="AI">AI</button><span class="definition">Kunstig intelligens, der kan analysere og generere indhold.</span></li>
+                <li><button class="glossary-term term" data-term="prompting">Prompting</button><span class="definition">At formulere spørgsmål eller instruktioner til en AI.</span></li>
+                <li><button class="glossary-term term" data-term="subnetting">Subnetting</button><span class="definition">Opdeling af et netværk i mindre segmenter.</span></li>
+                <li><button class="glossary-term term" data-term="DHCP">DHCP</button><span class="definition">Automatisk tildeling af IP-adresser på et netværk.</span></li>
+                <li><button class="glossary-term term" data-term="DNS">DNS</button><span class="definition">Oversætter domænenavne til IP-adresser.</span></li>
+                <li><button class="glossary-term term" data-term="netværk">Netværk</button><span class="definition">Forbindelser mellem enheder, der deler data.</span></li>
+                <li><button class="glossary-term term" data-term="differentiering">Differentiering</button><span class="definition">Tilpasning af undervisning til elevens niveau.</span></li>
+                <li><button class="glossary-term term" data-term="kritisk tænkning">Kritisk tænkning</button><span class="definition">At vurdere og analysere information med omtanke.</span></li>
+            </ul>
+        </section>
+
+        <section id="chat" class="section-card">
+            <h2>Chat om sidens emner</h2>
+            <p>Brug chatten til at stille korte spørgsmål om <span class="term" data-term="AI">AI</span> i undervisning, subnetting, programmering, <span class="term" data-term="netværk">netværk</span>, <span class="term" data-term="prompting">prompting</span> eller differentiering. Andre emner bliver høfligt afvist. Svarene er på dansk og hjælper dig til selv at tænke videre.</p>
+            <div id="chat-window" aria-live="polite"></div>
+            <form id="chat-form">
+                <label for="chat-input" class="sr-only">Skriv dit spørgsmål</label>
+                <textarea id="chat-input" rows="3" placeholder="Skriv dit spørgsmål her..." required maxlength="300"></textarea>
+                <button type="submit">Send spørgsmål</button>
+            </form>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <p>Undervisningsplatformen kan udvides med flere kapitler og fagområder. Kontakt underviserteamet for idéer og samarbejde.</p>
+    </footer>
+
+    <div id="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
+        <div class="modal-content">
+            <button class="modal-close" aria-label="Luk">&times;</button>
+            <h3 id="modal-title">Forklaring</h3>
+            <div id="modal-body"></div>
+        </div>
+    </div>
+
+    <script src="app.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,23 +11,28 @@
     <header class="site-header">
         <h1>AI i Undervisning: Fra Nysgerrighed til Praksis</h1>
         <p>Af Steen Hansen og Heino K Jensen – erfaringer fra ungdomsuddannelser med både helt unge og voksne elever</p>
-        <nav class="site-nav">
-            <a href="#forord">Forord</a>
-            <a href="#kapitel-1">Kapitel 1 – Hvad er AI i undervisningskontekst?</a>
-            <a href="#kapitel-2">Kapitel 2 – Kritiske perspektiver: Etik, risici og ansvar</a>
-            <a href="#kapitel-3">Kapitel 3 – Vores erfaringer med undervisningen og hvorfor vi gør som vi gør</a>
-            <a href="#kapitel-4">Kapitel 4 – Vores strategi og de pædagogiske gevinster</a>
-            <a href="#kapitel-6">Kapitel 6 – Didaktiske designmønstre med AI</a>
-            <a href="#kapitel-8">Kapitel 8 – Promptteknik og hvorfor det er vigtigt</a>
-            <a href="#kapitel-10">Kapitel 10 – Implementering</a>
-            <a href="#kapitel-11">Kapitel 11 – Typiske faldgruber og mine modtræk</a>
-            <a href="#bilag">Bilag</a>
-            <a href="#chat">Chat</a>
-            <a href="#fagordbog">Fagordbog</a>
-        </nav>
     </header>
 
-    <main>
+    <div class="content-layout">
+        <aside class="chapter-sidebar" aria-label="Kapiteloversigt">
+            <h2>Kapiteloversigt</h2>
+            <nav class="chapter-nav">
+                <a href="#forord">Forord</a>
+                <a href="#kapitel-1">Kapitel 1 – Hvad er AI i undervisningskontekst?</a>
+                <a href="#kapitel-2">Kapitel 2 – Kritiske perspektiver: Etik, risici og ansvar</a>
+                <a href="#kapitel-3">Kapitel 3 – Vores erfaringer med undervisningen og hvorfor vi gør som vi gør</a>
+                <a href="#kapitel-4">Kapitel 4 – Vores strategi og de pædagogiske gevinster</a>
+                <a href="#kapitel-6">Kapitel 6 – Didaktiske designmønstre med AI</a>
+                <a href="#kapitel-8">Kapitel 8 – Promptteknik og hvorfor det er vigtigt</a>
+                <a href="#kapitel-10">Kapitel 10 – Implementering</a>
+                <a href="#kapitel-11">Kapitel 11 – Typiske faldgruber og mine modtræk</a>
+                <a href="#bilag">Bilag</a>
+                <a href="#chat">Chat</a>
+                <a href="#fagordbog">Fagordbog</a>
+            </nav>
+        </aside>
+
+        <main>
         <section id="forord" class="section-card">
             <h2>Forord</h2>
             <p>Vi har arbejdet med <span class="term" data-term="AI">AI</span> i undervisning på ungdomsuddannelser – særligt erhvervs- og tekniske forløb – hvor holdene ofte rummer både helt unge elever og voksne med erfaring fra arbejde eller tidligere uddannelser. Det her er min praktiske vejledning: hvad virker i hverdagen, hvad bør man undgå, og hvordan får man ro på processen, så <span class="term" data-term="AI">AI</span> bliver et pædagogisk plus – ikke endnu et forstyrrende værktøj.</p>
@@ -289,6 +294,7 @@
             </form>
         </section>
     </main>
+    </div>
 
     <footer class="site-footer">
         <p>Undervisningsplatformen kan udvides med flere kapitler og fagområder. Kontakt underviserteamet for idéer og samarbejde.</p>

--- a/proxy.php
+++ b/proxy.php
@@ -1,0 +1,201 @@
+<?php
+declare(strict_types=1);
+
+header('Content-Type: application/json; charset=utf-8');
+
+require __DIR__ . '/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Kun POST-forespørgsler er tilladt.']);
+    exit;
+}
+
+$referer = $_SERVER['HTTP_REFERER'] ?? '';
+$refererAllowed = false;
+foreach ($ALLOWED_REFERERS as $allowed) {
+    if ($referer && str_starts_with($referer, $allowed)) {
+        $refererAllowed = true;
+        break;
+    }
+}
+
+if (!$refererAllowed) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Adgang nægtet: ugyldig referer.']);
+    exit;
+}
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Ugyldigt inputformat.']);
+    exit;
+}
+
+$type = $input['type'] ?? '';
+$ip = $_SERVER['REMOTE_ADDR'] ?? 'ukendt';
+
+if (!rateLimit($ip)) {
+    http_response_code(429);
+    echo json_encode(['error' => 'For mange forespørgsler. Vent lidt og prøv igen.']);
+    exit;
+}
+
+try {
+    switch ($type) {
+        case 'chat':
+            $message = trim((string)($input['message'] ?? ''));
+            if ($message === '' || mb_strlen($message) > 300) {
+                throw new RuntimeException('Spørgsmålet skal være udfyldt og under 300 tegn.');
+            }
+
+            if (!isTopicAllowed($message, $ALLOWED_TOPICS)) {
+                echo json_encode(['error' => 'Spørgsmålet ligger uden for sidens fokus. Prøv med et emne om AI, subnetting, programmering eller differentiering.']);
+                exit;
+            }
+
+            $prompt = buildChatPrompt($message);
+            $answer = callOpenAI($prompt, $OPENAI_API_KEY);
+            echo json_encode(['answer' => $answer]);
+            exit;
+
+        case 'glossary':
+            $term = trim((string)($input['term'] ?? ''));
+            if ($term === '' || mb_strlen($term) > 60) {
+                throw new RuntimeException('Fagordet mangler eller er for langt.');
+            }
+
+            $prompt = buildGlossaryPrompt($term);
+            $answer = callOpenAI($prompt, $OPENAI_API_KEY);
+            echo json_encode(['answer' => $answer]);
+            exit;
+
+        default:
+            throw new RuntimeException('Ukendt forespørgselstype.');
+    }
+} catch (RuntimeException $e) {
+    http_response_code(400);
+    echo json_encode(['error' => $e->getMessage()]);
+    exit;
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Der opstod en uventet fejl.']);
+    exit;
+}
+
+function rateLimit(string $ip): bool
+{
+    $windowSeconds = 60;
+    $maxRequests = 20;
+    $file = sys_get_temp_dir() . '/ai_teaching_rate_limit.json';
+    $now = time();
+
+    $handle = fopen($file, 'c+');
+    if ($handle === false) {
+        return false;
+    }
+
+    try {
+        flock($handle, LOCK_EX);
+        $contents = stream_get_contents($handle);
+        $data = $contents ? json_decode($contents, true) : [];
+        if (!is_array($data)) {
+            $data = [];
+        }
+
+        $requests = $data[$ip] ?? [];
+        $requests = array_filter($requests, static fn($timestamp) => ($now - (int)$timestamp) < $windowSeconds);
+
+        if (count($requests) >= $maxRequests) {
+            return false;
+        }
+
+        $requests[] = $now;
+        $data[$ip] = array_values($requests);
+
+        ftruncate($handle, 0);
+        rewind($handle);
+        fwrite($handle, json_encode($data));
+        fflush($handle);
+    } finally {
+        flock($handle, LOCK_UN);
+        fclose($handle);
+    }
+
+    return true;
+}
+
+function isTopicAllowed(string $message, array $allowedTopics): bool
+{
+    $normalized = mb_strtolower($message);
+    foreach ($allowedTopics as $topic) {
+        if (str_contains($normalized, mb_strtolower($topic))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function buildChatPrompt(string $message): array
+{
+    $system = 'Du er en dansk undervisningsassistent for GF2 Data-elever. Svar kort, venligt og opmuntrende, og hjælp eleven til selv at tænke videre. Brug maks. 80 ord og fokuser på AI i undervisning, differentiering, subnetting, programmering, netværk og prompting. Afvis andre emner høfligt.';
+    return [
+        'model' => 'gpt-4o-mini',
+        'messages' => [
+            ['role' => 'system', 'content' => $system],
+            ['role' => 'user', 'content' => $message]
+        ],
+        'max_tokens' => 220,
+        'temperature' => 0.6
+    ];
+}
+
+function buildGlossaryPrompt(string $term): array
+{
+    $system = 'Du er en dansk teknisk glossemaskine til GF2 Data. Giv en kort og pædagogisk forklaring på maks. 40 ord. Inkludér ét konkret eksempel eller hverdagssammenligning. Undgå kodeblokke.';
+    $user = "Forklar begrebet '{$term}' i sammenhæng med AI-støttet undervisning, netværk eller programmering.";
+    return [
+        'model' => 'gpt-4o-mini',
+        'messages' => [
+            ['role' => 'system', 'content' => $system],
+            ['role' => 'user', 'content' => $user]
+        ],
+        'max_tokens' => 160,
+        'temperature' => 0.5
+    ];
+}
+
+function callOpenAI(array $payload, string $apiKey): string
+{
+    $ch = curl_init('https://api.openai.com/v1/chat/completions');
+    curl_setopt_array($ch, [
+        CURLOPT_POST => true,
+        CURLOPT_HTTPHEADER => [
+            'Content-Type: application/json',
+            'Authorization: Bearer ' . $apiKey
+        ],
+        CURLOPT_POSTFIELDS => json_encode($payload),
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT => 20
+    ]);
+
+    $response = curl_exec($ch);
+    if ($response === false) {
+        throw new RuntimeException('Kunne ikke kontakte OpenAI: ' . curl_error($ch));
+    }
+
+    $status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    curl_close($ch);
+
+    if ($status >= 400) {
+        throw new RuntimeException('OpenAI returnerede en fejl.');
+    }
+
+    $decoded = json_decode($response, true);
+    if (!isset($decoded['choices'][0]['message']['content'])) {
+        throw new RuntimeException('Ugyldigt svar fra OpenAI.');
+    }
+
+    return trim($decoded['choices'][0]['message']['content']);
+}

--- a/proxy.php
+++ b/proxy.php
@@ -51,7 +51,7 @@ try {
             }
 
             if (!isTopicAllowed($message, $ALLOWED_TOPICS)) {
-                echo json_encode(['error' => 'Spørgsmålet ligger uden for sidens fokus. Prøv med et emne om AI, subnetting, programmering eller differentiering.']);
+                echo json_encode(['error' => 'Spørgsmålet ligger uden for sidens fokus. Prøv med et emne om AI i undervisning, didaktik, programmering eller differentiering.']);
                 exit;
             }
 
@@ -139,7 +139,7 @@ function isTopicAllowed(string $message, array $allowedTopics): bool
 
 function buildChatPrompt(string $message): array
 {
-    $system = 'Du er en dansk undervisningsassistent for GF2 Data-elever. Svar kort, venligt og opmuntrende, og hjælp eleven til selv at tænke videre. Brug maks. 80 ord og fokuser på AI i undervisning, differentiering, subnetting, programmering, netværk og prompting. Afvis andre emner høfligt.';
+    $system = 'Du er en dansk undervisningsassistent for GF2 Data-elever. Svar kort, venligt og opmuntrende, og hjælp eleven til selv at tænke videre. Brug maks. 80 ord og fokuser på AI i undervisning, didaktik, differentiering, netværk, programmering og prompting. Afvis andre emner høfligt.';
     return [
         'model' => 'gpt-4o-mini',
         'messages' => [

--- a/styles.css
+++ b/styles.css
@@ -91,6 +91,7 @@ main {
     border-radius: 16px;
     box-shadow: 0 20px 45px rgba(8, 47, 73, 0.35);
     border: 1px solid rgba(56, 189, 248, 0.08);
+    scroll-margin-top: 7rem;
 }
 
 .section-card h2 {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,382 @@
+:root {
+    color-scheme: dark;
+    --bg-color: #0f172a;
+    --card-color: #1e293b;
+    --accent: #38bdf8;
+    --text-color: #f8fafc;
+    --muted: #94a3b8;
+    --warning: #f97316;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: var(--bg-color);
+    color: var(--text-color);
+    line-height: 1.6;
+    user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    overflow-x: hidden;
+}
+
+body::-webkit-scrollbar {
+    width: 10px;
+}
+
+body::-webkit-scrollbar-thumb {
+    background: rgba(148, 163, 184, 0.6);
+    border-radius: 6px;
+}
+
+.site-header {
+    background: rgba(15, 23, 42, 0.9);
+    padding: 2rem 1.5rem 1rem;
+    text-align: center;
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    backdrop-filter: blur(12px);
+}
+
+.site-header h1 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+.site-header p {
+    color: var(--muted);
+}
+
+.site-nav {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.site-nav a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0.35rem 0.75rem;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    transition: all 0.2s ease;
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+    border-color: var(--accent);
+    background: rgba(56, 189, 248, 0.1);
+}
+
+main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 1.5rem;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.section-card {
+    background: var(--card-color);
+    padding: 1.75rem;
+    border-radius: 16px;
+    box-shadow: 0 20px 45px rgba(8, 47, 73, 0.35);
+    border: 1px solid rgba(56, 189, 248, 0.08);
+}
+
+.section-card h2 {
+    margin-bottom: 1rem;
+    font-size: 1.75rem;
+}
+
+.section-card h3 {
+    margin: 1.25rem 0 0.75rem;
+    font-size: 1.2rem;
+}
+
+.section-card p + p {
+    margin-top: 0.75rem;
+}
+
+ul, ol {
+    margin-left: 1.5rem;
+    margin-top: 0.75rem;
+    display: grid;
+    gap: 0.5rem;
+}
+
+table.data-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+    overflow: hidden;
+    border-radius: 12px;
+}
+
+table.data-table th,
+table.data-table td {
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    padding: 0.75rem;
+    text-align: left;
+}
+
+table.data-table thead {
+    background: rgba(56, 189, 248, 0.15);
+}
+
+.prompt-list blockquote {
+    background: rgba(15, 23, 42, 0.6);
+    border-left: 4px solid var(--accent);
+    padding: 0.75rem 1rem;
+    border-radius: 6px;
+    color: var(--muted);
+}
+
+.interactive-panels details {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(56, 189, 248, 0.2);
+    border-radius: 12px;
+    padding: 1rem;
+    margin-top: 1rem;
+}
+
+.interactive-panels summary {
+    cursor: pointer;
+    font-weight: 700;
+    color: var(--accent);
+}
+
+.term {
+    color: var(--accent);
+    cursor: pointer;
+    position: relative;
+    transition: color 0.2s ease;
+}
+
+.term::after {
+    content: '\1F4A1';
+    font-size: 0.75rem;
+    margin-left: 0.25rem;
+    opacity: 0.8;
+}
+
+.term:hover,
+.term:focus {
+    color: #facc15;
+}
+
+#fagordbog input {
+    width: 100%;
+    padding: 0.75rem;
+    border-radius: 999px;
+    border: 1px solid rgba(56, 189, 248, 0.2);
+    background: rgba(15, 23, 42, 0.8);
+    color: var(--text-color);
+    margin-bottom: 1rem;
+}
+
+#glossary-list {
+    list-style: none;
+    margin-left: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+#glossary-list li {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.75rem 1rem;
+    background: rgba(15, 23, 42, 0.7);
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.glossary-term {
+    align-self: flex-start;
+    background: rgba(56, 189, 248, 0.12);
+    border: 1px solid rgba(56, 189, 248, 0.4);
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+    color: var(--accent);
+    font-weight: 600;
+}
+
+.definition {
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+#chat-window {
+    background: rgba(15, 23, 42, 0.7);
+    border-radius: 16px;
+    border: 1px solid rgba(56, 189, 248, 0.2);
+    padding: 1rem;
+    min-height: 200px;
+    max-height: 320px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.message {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.message.user {
+    align-items: flex-end;
+}
+
+.message.user .bubble {
+    background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+    color: #0f172a;
+    border-radius: 14px 14px 0 14px;
+}
+
+.message.bot {
+    align-items: flex-start;
+}
+
+.message.bot .bubble {
+    background: rgba(56, 189, 248, 0.15);
+    border-radius: 14px 14px 14px 0;
+    border: 1px solid rgba(56, 189, 248, 0.2);
+}
+
+.bubble {
+    padding: 0.65rem 0.85rem;
+    max-width: 90%;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    box-shadow: 0 10px 25px rgba(8, 47, 73, 0.35);
+}
+
+#chat-form {
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+#chat-input {
+    background: rgba(15, 23, 42, 0.8);
+    color: var(--text-color);
+    border-radius: 12px;
+    border: 1px solid rgba(56, 189, 248, 0.2);
+    padding: 0.75rem;
+    resize: vertical;
+}
+
+#chat-form button {
+    align-self: flex-end;
+    background: var(--accent);
+    color: #0f172a;
+    font-weight: 700;
+    border: none;
+    border-radius: 999px;
+    padding: 0.6rem 1.4rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#chat-form button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 30px rgba(56, 189, 248, 0.35);
+}
+
+.site-footer {
+    text-align: center;
+    padding: 2rem 1rem 3rem;
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+#modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+}
+
+#modal[hidden] {
+    display: none;
+}
+
+.modal-content {
+    background: var(--card-color);
+    padding: 1.5rem;
+    border-radius: 16px;
+    max-width: 480px;
+    width: 100%;
+    border: 1px solid rgba(56, 189, 248, 0.2);
+    position: relative;
+}
+
+.modal-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    color: var(--muted);
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+.modal-close:hover {
+    color: var(--accent);
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
+@media (max-width: 768px) {
+    .site-header h1 {
+        font-size: 1.5rem;
+    }
+
+    .section-card {
+        padding: 1.25rem;
+    }
+
+    .site-nav {
+        gap: 0.5rem;
+    }
+
+    .site-nav a {
+        font-size: 0.85rem;
+    }
+
+    #chat-window {
+        max-height: 260px;
+    }
+}
+
+@media print {
+    * {
+        user-select: text !important;
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -53,36 +53,63 @@ body::-webkit-scrollbar-thumb {
     color: var(--muted);
 }
 
-.site-nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.75rem;
-    margin-top: 1rem;
-}
-
-.site-nav a {
-    color: var(--accent);
-    text-decoration: none;
-    font-weight: 600;
-    padding: 0.35rem 0.75rem;
-    border: 1px solid transparent;
-    border-radius: 999px;
-    transition: all 0.2s ease;
-}
-
-.site-nav a:hover,
-.site-nav a:focus {
-    border-color: var(--accent);
-    background: rgba(56, 189, 248, 0.1);
-}
-
-main {
-    max-width: 1100px;
+.content-layout {
+    max-width: 1200px;
     margin: 0 auto;
     padding: 1.5rem;
     display: grid;
+    grid-template-columns: minmax(200px, 260px) minmax(0, 1fr);
     gap: 1.5rem;
+    align-items: start;
+}
+
+.chapter-sidebar {
+    background: rgba(15, 23, 42, 0.85);
+    border: 1px solid rgba(56, 189, 248, 0.15);
+    border-radius: 18px;
+    box-shadow: 0 25px 40px rgba(8, 47, 73, 0.35);
+    padding: 1.5rem 1.25rem;
+    position: sticky;
+    top: 7.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.chapter-sidebar h2 {
+    font-size: 1.15rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+}
+
+.chapter-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.chapter-nav a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0.45rem 0.75rem;
+    border-radius: 10px;
+    transition: all 0.2s ease;
+    border: 1px solid transparent;
+    display: block;
+}
+
+.chapter-nav a:hover,
+.chapter-nav a:focus {
+    border-color: var(--accent);
+    background: rgba(56, 189, 248, 0.12);
+}
+
+main {
+    display: grid;
+    gap: 1.5rem;
+    min-width: 0;
 }
 
 .section-card {
@@ -354,21 +381,45 @@ table.data-table thead {
     border: 0;
 }
 
+@media (max-width: 1024px) {
+    .content-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .chapter-sidebar {
+        position: static;
+        top: auto;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .chapter-nav {
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .chapter-nav a {
+        flex: 1 1 48%;
+        text-align: center;
+    }
+}
+
 @media (max-width: 768px) {
     .site-header h1 {
         font-size: 1.5rem;
+    }
+
+    .content-layout {
+        padding: 1.25rem;
     }
 
     .section-card {
         padding: 1.25rem;
     }
 
-    .site-nav {
-        gap: 0.5rem;
-    }
-
-    .site-nav a {
-        font-size: 0.85rem;
+    .chapter-nav a {
+        flex: 1 1 100%;
     }
 
     #chat-window {


### PR DESCRIPTION
## Summary
- remove the subnetting navigation link and tutorial section from the landing page so the content matches the source document

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee3f9d77c8832a8a8e0fd31f9365c7